### PR TITLE
Use Structured Logging in a More Structured Way

### DIFF
--- a/src/Amazon.CloudWatch.EMF/Environment/ECSEnvironment.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/ECSEnvironment.cs
@@ -151,7 +151,7 @@ namespace Amazon.CloudWatch.EMF.Environment
             _fluentBitEndpoint = string.Format("tcp://%s:%d", fluentHost, Constants.DEFAULT_AGENT_PORT);
             _configuration.AgentEndPoint = _fluentBitEndpoint;
 
-            _logger.LogInformation("Using FluentBit configuration. Endpoint: {}", _fluentBitEndpoint);
+            _logger.LogInformation("Using FluentBit configuration. Endpoint: {Endpoint}", _fluentBitEndpoint);
         }
 
         private void FormatImageName()

--- a/src/Amazon.CloudWatch.EMF/Logger/MetricsLogger.cs
+++ b/src/Amazon.CloudWatch.EMF/Logger/MetricsLogger.cs
@@ -82,7 +82,7 @@ namespace Amazon.CloudWatch.EMF.Logger
                 throw new InvalidOperationException(message);
             }
 
-            _logger.LogDebug("Sending data to sink. {}", _environment.Sink.GetType().Name);
+            _logger.LogDebug("Sending data to sink: {SinkName}", _environment.Sink.GetType().Name);
 
             _environment.Sink.Accept(_context);
             _context = _context.CreateCopyWithContext();

--- a/src/Amazon.CloudWatch.EMF/Sink/AgentSink.cs
+++ b/src/Amazon.CloudWatch.EMF/Sink/AgentSink.cs
@@ -68,7 +68,7 @@ namespace Amazon.CloudWatch.EMF.Sink
                     }
                     catch (InvalidOperationException e)
                     {
-                        _logger.LogError("Attempted to publish data after the sink has been shutdown. {}", e);
+                        _logger.LogError(e, "Attempted to publish data after the sink has been shutdown.");
                     }
 
                     _logger.LogDebug("Data queued successfully.");
@@ -76,7 +76,7 @@ namespace Amazon.CloudWatch.EMF.Sink
             }
             catch (Exception e)
             {
-                _logger.LogError("Failed to serialize the metrics with the exception: {}", e);
+                _logger.LogError(e, "Failed to serialize the metrics.");
             }
         }
 
@@ -118,7 +118,7 @@ namespace Amazon.CloudWatch.EMF.Sink
                             }
                             catch (Exception e)
                             {
-                                logger.LogWarning("Failed to write message to socket. Backing off and trying again. {}", e.Message);
+                                logger.LogWarning(e, "Failed to write message to socket. Backing off and trying again.");
                                 Thread.Sleep(1000); // TODO: backoff
                             }
                         }

--- a/src/Amazon.CloudWatch.EMF/Sink/ConsoleSink.cs
+++ b/src/Amazon.CloudWatch.EMF/Sink/ConsoleSink.cs
@@ -35,7 +35,7 @@ namespace Amazon.CloudWatch.EMF.Sink
             }
             catch (Exception e)
             {
-                _logger.LogError("Failed to serialize a MetricsContext: {}", e);
+                _logger.LogError(e, "Failed to serialize a MetricsContext.");
             }
         }
 

--- a/src/Amazon.CloudWatch.EMF/Sink/Endpoint.cs
+++ b/src/Amazon.CloudWatch.EMF/Sink/Endpoint.cs
@@ -31,7 +31,7 @@ namespace Amazon.CloudWatch.EMF.Sink
             }
             catch (UriFormatException)
             {
-                logger.LogWarning("Failed to parse the endpoint: {} ", url);
+                logger.LogWarning("Failed to parse the endpoint: {Url} ", url);
                 SetDefault();
             }
 
@@ -51,7 +51,7 @@ namespace Amazon.CloudWatch.EMF.Sink
             catch (Exception)
             {
                 logger.LogWarning(
-                    "Unsupported protocol: {}. Would use default endpoint: {}",
+                    "Unsupported protocol: {Url}. Would use default endpoint: {Endpoint}",
                     url,
                     DEFAULT_TCP_ENDPOINT);
 


### PR DESCRIPTION
*Description of changes:*

In several places, empty curly braces (`{}`) were used in place of
structured logging properties. These were processed as literal
curly braces in logs, and log context was lost. Where the value of
the property was an exception, an Exception-specialized overload
was chosen instead.

This did not alter any places where string interpolation was used
instead of structured logging properties. That could be work for
the future.

**By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.**
