### PR TITLE
Migrate from IMDSv1 to IMDSv2

### DIFF
--- a/src/Amazon.CloudWatch.EMF/Amazon.CloudWatch.EMF.csproj
+++ b/src/Amazon.CloudWatch.EMF/Amazon.CloudWatch.EMF.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>Amazon.CloudWatch.EMF</PackageId>
-        <VersionPrefix>0.1.0</VersionPrefix>
+        <VersionPrefix>0.1.1</VersionPrefix>
         <Authors>Amazon Web Services</Authors>
         <Description>Amazon CloudWatch Embedded Metric Format Client Library</Description>
         <Language>en-US</Language>

--- a/src/Amazon.CloudWatch.EMF/Environment/ECSEnvironment.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/ECSEnvironment.cs
@@ -52,7 +52,7 @@ namespace Amazon.CloudWatch.EMF.Environment
             try
             {
                 var parsedUri = new Uri(uri);
-                _ecsMetadata = _resourceFetcher.Fetch<ECSMetadata>(parsedUri);
+                _ecsMetadata = _resourceFetcher.FetchJson<ECSMetadata>(parsedUri, "GET");
                 FormatImageName();
                 return true;
             }

--- a/src/Amazon.CloudWatch.EMF/Environment/IResourceFetcher.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/IResourceFetcher.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
 
 namespace Amazon.CloudWatch.EMF.Environment
 {
     public interface IResourceFetcher
     {
-        public T Fetch<T>(Uri endpoint);
+        public T FetchJson<T>(Uri endpoint, string method, Dictionary<string, string> header = null);
+
+        public string FetchString(Uri endpoint, string method, Dictionary<string, string> header = null);
     }
 }

--- a/tests/Amazon.CloudWatch.EMF.Tests/Environment/EC2EnvironmentTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Environment/EC2EnvironmentTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Amazon.CloudWatch.EMF.Config;
 using Amazon.CloudWatch.EMF.Environment;
 using AutoFixture;
@@ -167,7 +168,9 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             // Arrange
             var configuration = _fixture.Create<IConfiguration>();
             var resourceFetcher = _fixture.Create<IResourceFetcher>();
-            resourceFetcher.Fetch<EC2Metadata>(Arg.Any<Uri>()).Throws<EMFClientException>();
+            resourceFetcher.FetchString(
+                Arg.Any<Uri>(), Arg.Any<string>(), Arg.Any<Dictionary<string, string>>()
+                ).Throws<EMFClientException>();
             var environment = new EC2Environment(configuration, resourceFetcher);
 
             // Act
@@ -183,7 +186,12 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             // Arrange
             var configuration = _fixture.Create<IConfiguration>();
             var resourceFetcher = _fixture.Create<IResourceFetcher>();
-            resourceFetcher.Fetch<EC2Metadata>(Arg.Any<Uri>()).Throws<EMFClientException>();
+            resourceFetcher.FetchString(
+                Arg.Any<Uri>(), Arg.Any<string>(), Arg.Any<Dictionary<string, string>>()
+                ).Returns("fake_token");
+            resourceFetcher.FetchJson<EC2Metadata>(
+                Arg.Any<Uri>(), Arg.Any<string>(), Arg.Any<Dictionary<string, string>>()
+                ).Throws<EMFClientException>();
             var environment = new EC2Environment(configuration, resourceFetcher);
             environment.Probe();
 
@@ -199,7 +207,12 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             // Arrange
             var configuration = _fixture.Create<IConfiguration>();
             var resourceFetcher = _fixture.Create<IResourceFetcher>();
-            resourceFetcher.Fetch<EC2Metadata>(Arg.Any<Uri>()).Returns(new EC2Metadata());
+            resourceFetcher.FetchString(
+                Arg.Any<Uri>(), Arg.Any<string>(), Arg.Any<Dictionary<string, string>>()
+                ).Returns("fake_token");
+            resourceFetcher.FetchJson<EC2Metadata>(
+                Arg.Any<Uri>(), Arg.Any<string>(), Arg.Any<Dictionary<string, string>>()
+                ).Returns(new EC2Metadata());
             var environment = new EC2Environment(configuration, resourceFetcher);
             environment.Probe();
 

--- a/tests/Amazon.CloudWatch.EMF.Tests/Environment/ECSEnvironmentTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Environment/ECSEnvironmentTests.cs
@@ -152,7 +152,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             // Arrange
             var configuration = _fixture.Create<IConfiguration>();
             var resourceFetcher = _fixture.Create<IResourceFetcher>();
-            resourceFetcher.Fetch<ECSMetadata>(Arg.Any<Uri>()).Throws<EMFClientException>();
+            resourceFetcher.FetchJson<ECSMetadata>(Arg.Any<Uri>(), Arg.Any<string>()).Throws<EMFClientException>();
             var environment = new ECSEnvironment(configuration, resourceFetcher);
 
             // Act


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- IMDSv2 uses session authentication to retrieve EC2 instance metadata.
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
- Updated to use `HttpClient` class as `HttpWebRequest` is not recommended anymore


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
