### PR TITLE
Upgrade .Net SDK to latest 3.1.x (CVE 2022-30184)

### DIFF
--- a/buildspecs/buildspec.canary.yml
+++ b/buildspecs/buildspec.canary.yml
@@ -20,5 +20,5 @@ phases:
       # install the latest patch version of 3.1
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 3.1
       - dotnet --version
-      - dotnet nuget help
+      - dotnet nuget --version
       - ./scripts/deploy-canary.sh

--- a/buildspecs/buildspec.canary.yml
+++ b/buildspecs/buildspec.canary.yml
@@ -17,4 +17,8 @@ phases:
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
   build:
     commands:
+      # install the latest patch version of 3.1
+      - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 3.1
+      - dotnet --version
+      - dotnet nuget help | head -1
       - ./scripts/deploy-canary.sh

--- a/buildspecs/buildspec.canary.yml
+++ b/buildspecs/buildspec.canary.yml
@@ -20,5 +20,5 @@ phases:
       # install the latest patch version of 3.1
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 3.1
       - dotnet --version
-      - dotnet nuget help | head -1
+      - dotnet nuget help
       - ./scripts/deploy-canary.sh

--- a/buildspecs/buildspec.release.yml
+++ b/buildspecs/buildspec.release.yml
@@ -11,5 +11,9 @@ phases:
       dotnet: 3.1
   build:
     commands:
+      # install the latest patch version of 3.1
+      - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 3.1
+      - dotnet --version
+      - dotnet nuget help | head -1
       - dotnet restore
       - ./scripts/publish-package.sh

--- a/buildspecs/buildspec.release.yml
+++ b/buildspecs/buildspec.release.yml
@@ -14,6 +14,6 @@ phases:
       # install the latest patch version of 3.1
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 3.1
       - dotnet --version
-      - dotnet nuget help | head -1
+      - dotnet nuget help
       - dotnet restore
       - ./scripts/publish-package.sh

--- a/buildspecs/buildspec.release.yml
+++ b/buildspecs/buildspec.release.yml
@@ -14,6 +14,6 @@ phases:
       # install the latest patch version of 3.1
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 3.1
       - dotnet --version
-      - dotnet nuget help
+      - dotnet nuget --version
       - dotnet restore
       - ./scripts/publish-package.sh

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -9,7 +9,7 @@ env:
 phases:
   install:
     runtime-versions:
-      dotnet: 3.x
+      dotnet: 3.1
     commands:
       # start docker
       # https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html#sample-docker-custom-image-files

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -20,6 +20,7 @@ phases:
       # install the latest patch version of 3.1
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 3.1
       - dotnet --version
+      - dotnet nuget help | head -1
       - pwd && ./scripts/start-agent.sh
       - dotnet restore
       - dotnet build

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -17,8 +17,7 @@ phases:
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
   build:
     commands:
-      - dotnet --info
-      - nuget
+      - dotnet --version
       - pwd && ./scripts/start-agent.sh
       - dotnet restore
       - dotnet build

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -20,7 +20,7 @@ phases:
       # install the latest patch version of 3.1
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 3.1
       - dotnet --version
-      - dotnet nuget help
+      - dotnet nuget --version
       - pwd && ./scripts/start-agent.sh
       - dotnet restore
       - dotnet build

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -20,7 +20,7 @@ phases:
       # install the latest patch version of 3.1
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 3.1
       - dotnet --version
-      - dotnet nuget help | head -1
+      - dotnet nuget help
       - pwd && ./scripts/start-agent.sh
       - dotnet restore
       - dotnet build

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -18,7 +18,7 @@ phases:
   build:
     commands:
       - dotnet --version
-      - curl -s https://dot.net/v1/dotnet-install.sh | sh -s -c 3.1
+      - curl -s https://dot.net/v1/dotnet-install.sh | bash -s -- -c 3.1
       - dotnet --version
       - exit 0
 #      - pwd && ./scripts/start-agent.sh

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -17,11 +17,10 @@ phases:
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
   build:
     commands:
-      - dotnet --version
+      # install the latest patch version of 3.1
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 3.1
       - dotnet --version
-      - exit 0
-#      - pwd && ./scripts/start-agent.sh
-#      - dotnet restore
-#      - dotnet build
-#      - dotnet test
+      - pwd && ./scripts/start-agent.sh
+      - dotnet restore
+      - dotnet build
+      - dotnet test

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -9,7 +9,7 @@ env:
 phases:
   install:
     runtime-versions:
-      dotnet: 3.1.x
+      dotnet: 3.x
     commands:
       # start docker
       # https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html#sample-docker-custom-image-files

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -18,7 +18,7 @@ phases:
   build:
     commands:
       - dotnet --version
-      - curl -s https://dot.net/v1/dotnet-install.sh | bash -s -- -c 3.1
+      - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 3.1
       - dotnet --version
       - exit 0
 #      - pwd && ./scripts/start-agent.sh

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -9,7 +9,7 @@ env:
 phases:
   install:
     runtime-versions:
-      dotnet: 3.1
+      dotnet: 3.1.x
     commands:
       # start docker
       # https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html#sample-docker-custom-image-files

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -17,6 +17,8 @@ phases:
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
   build:
     commands:
+      - dotnet --info
+      - nuget
       - pwd && ./scripts/start-agent.sh
       - dotnet restore
       - dotnet build

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -18,7 +18,7 @@ phases:
   build:
     commands:
       - dotnet --version
-      - curl -s https://dot.net/v1/dotnet-install.sh | bash -s -c 3.1
+      - curl -s https://dot.net/v1/dotnet-install.sh | sh -s -c 3.1
       - dotnet --version
       - exit 0
 #      - pwd && ./scripts/start-agent.sh

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -18,7 +18,10 @@ phases:
   build:
     commands:
       - dotnet --version
-      - pwd && ./scripts/start-agent.sh
-      - dotnet restore
-      - dotnet build
-      - dotnet test
+      - curl -s https://dot.net/v1/dotnet-install.sh | bash -s -c 3.1
+      - dotnet --version
+      - exit 0
+#      - pwd && ./scripts/start-agent.sh
+#      - dotnet restore
+#      - dotnet build
+#      - dotnet test


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Using .Net install script from https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script to install the latest patch version of 3.1.x of the SDK.
At the time of writing, it installs .Net Core 3.1.421 and NuGet 5.7.2.7 which fixes CVE 2022-30184.
More information here: https://github.com/NuGet/Announcements/issues/62

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
