### PR TITLE
Fix: prevent duplicate dimensions

### DIFF
--- a/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
@@ -80,6 +80,25 @@ namespace Amazon.CloudWatch.EMF.Model
             }
         }
 
+        internal void PutDimension(DimensionSet dimensionSet)
+        {
+            // Duplicate dimensions sets are removed before being added to the end of the collection.
+            // This ensures the latest dimension key-value is used as a target member on the root EMF node.
+            // This operation is O(n^2), but acceptable given sets are capped at 10 dimensions
+            List<string> incomingDimensionSetKeys = dimensionSet.DimensionKeys;
+            CustomDimensionSets = CustomDimensionSets.Where(existingDimensionSet =>
+            {
+                if (existingDimensionSet.DimensionKeys.Count != incomingDimensionSetKeys.Count)
+                {
+                    return true;
+                }
+
+                return !existingDimensionSet.DimensionKeys.All(existingDimensionSetKey => incomingDimensionSetKeys.Contains(existingDimensionSetKey));
+            }).ToList();
+
+            CustomDimensionSets.Add(dimensionSet);
+        }
+
         /// <summary>
         /// Overrides all existing dimensions, including suppressing any default dimensions.
         /// </summary>

--- a/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
@@ -84,7 +84,7 @@ namespace Amazon.CloudWatch.EMF.Model
         {
             // Duplicate dimensions sets are removed before being added to the end of the collection.
             // This ensures the latest dimension key-value is used as a target member on the root EMF node.
-            // This operation is O(n^2), but acceptable given sets are capped at 10 dimensions
+            // This operation is O(n^2), but acceptable given sets are capped at 30 dimensions
             List<string> incomingDimensionSetKeys = dimensionSet.DimensionKeys;
             CustomDimensionSets = CustomDimensionSets.Where(existingDimensionSet =>
             {

--- a/src/Amazon.CloudWatch.EMF/Model/MetricsContext.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricsContext.cs
@@ -151,7 +151,7 @@ namespace Amazon.CloudWatch.EMF.Model
         /// <param name="dimensionSet">the dimensions set to add.</param>
         public void PutDimension(DimensionSet dimensionSet)
         {
-            _metricDirective.CustomDimensionSets.Add(dimensionSet);
+            _metricDirective.PutDimension(dimensionSet);
         }
 
         /// <summary>
@@ -166,7 +166,7 @@ namespace Amazon.CloudWatch.EMF.Model
         {
             var dimensionSet = new DimensionSet();
             dimensionSet.AddDimension(dimension, value);
-            _metricDirective.CustomDimensionSets.Add(dimensionSet);
+            _metricDirective.PutDimension(dimensionSet);
         }
 
         /// <summary>

--- a/tests/Amazon.CloudWatch.EMF.Tests/Logger/MetricsLoggerTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Logger/MetricsLoggerTests.cs
@@ -94,6 +94,50 @@ namespace Amazon.CloudWatch.EMF.Tests.Logger
         }
 
         [Fact]
+        public void TestPutDuplicateDimensions()
+        {
+            string dimensionName1 = "dim1";
+            string dimensionName2 = "dim2";
+            string dimensionValue1 = "dimValue1";
+            string dimensionValue2 = "dimValue2";
+            string dimensionValue3 = "dimValue3";
+            string dimensionValue4 = "dimValue4";
+
+            _metricsLogger.PutDimensions(new DimensionSet(dimensionName1, dimensionValue1));
+            _metricsLogger.PutDimensions(new DimensionSet(dimensionName2, dimensionValue2));
+            _metricsLogger.PutDimensions(new DimensionSet(dimensionName1, dimensionValue3));
+            _metricsLogger.PutDimensions(new DimensionSet(dimensionName2, dimensionValue4));
+            _metricsLogger.Flush();
+
+            Assert.Equal(4, _sink.MetricsContext.GetAllDimensionSets()[0].DimensionKeys.Count);
+            Assert.Equal(dimensionValue3, _sink.MetricsContext.GetAllDimensionSets()[0].GetDimensionValue(dimensionName1));
+            Assert.Equal(dimensionValue4, _sink.MetricsContext.GetAllDimensionSets()[0].GetDimensionValue(dimensionName2));
+        }
+
+        [Fact]
+        public void TestSetPutDuplicateDimensions()
+        {
+            string dimensionName1 = "dim1";
+            string dimensionName2 = "dim2";
+            string dimensionName3 = "dim3";
+            string dimensionValue1 = "dimValue1";
+            string dimensionValue2 = "dimValue2";
+            string dimensionValue3 = "dimValue3";
+            string dimensionValue4 = "dimValue4";
+
+            _metricsLogger.PutDimensions(new DimensionSet(dimensionName1, dimensionValue1));
+            _metricsLogger.SetDimensions(new DimensionSet(dimensionName2, dimensionValue1));
+            _metricsLogger.PutDimensions(new DimensionSet(dimensionName3, dimensionValue2));
+            _metricsLogger.PutDimensions(new DimensionSet(dimensionName2, dimensionValue3));
+            _metricsLogger.PutDimensions(new DimensionSet(dimensionName3, dimensionValue4));
+            _metricsLogger.Flush();
+
+            Assert.Equal(2, _sink.MetricsContext.GetAllDimensionSets().Count);
+            Assert.Equal(dimensionValue3, _sink.MetricsContext.GetAllDimensionSets()[0].GetDimensionValue(dimensionName2));
+            Assert.Equal(dimensionValue4, _sink.MetricsContext.GetAllDimensionSets()[1].GetDimensionValue(dimensionName3));
+        }
+
+        [Fact]
         public void TestSetNameSpace()
         {
             string namespaceValue = "TestNamespace";


### PR DESCRIPTION
*Issue #, if available:* #31

*Description of changes:*
Any duplicate dimension set in `putDimensions()` will replace the existing dimension set such that the newer/latest dimension value is used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
