### PR TITLE
handle all exceptions to avoid system crash

### DIFF
--- a/src/Amazon.CloudWatch.EMF/Environment/EC2Environment.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/EC2Environment.cs
@@ -57,7 +57,7 @@ namespace Amazon.CloudWatch.EMF.Environment
             {
                 _token = _resourceFetcher.FetchString(tokenUri, "PUT", tokenRequestHeader);
             }
-            catch (EMFClientException ex)
+            catch (Exception ex)
             {
                 _logger.LogDebug("Failed to get response from: " + tokenUri, ex);
                 return false;
@@ -81,7 +81,7 @@ namespace Amazon.CloudWatch.EMF.Environment
                 _ec2Metadata = _resourceFetcher.FetchJson<EC2Metadata>(metadataUri, "GET", metadataRequestHeader);
                 return true;
             }
-            catch (EMFClientException ex)
+            catch (Exception ex)
             {
                 _logger.LogDebug("Failed to get response from: " + metadataUri, ex);
             }


### PR DESCRIPTION
*Description of changes:*
While executing the example from ReadMe (which uses default environment), the program tries to resolve the environment and crashes while trying to probe for EC2 due to an unhandled exception. Hence it is not able proceed and probe for default environment. To handle all possible exceptions, made changes to catch generic exceptions. Similar behaviour can also be seen in [EMF Python Library.](https://github.com/awslabs/aws-embedded-metrics-python/blob/master/aws_embedded_metrics/environment/ec2_environment.py)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
