### PR TITLE
Update dotnet version to 6.0

### DIFF
--- a/tests/Amazon.CloudWatch.EMF.Canary/Amazon.CloudWatch.EMF.Canary.csproj
+++ b/tests/Amazon.CloudWatch.EMF.Canary/Amazon.CloudWatch.EMF.Canary.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Amazon.CloudWatch.EMF.IntegrationTests/Amazon.CloudWatch.EMF.IntegrationTests.csproj
+++ b/tests/Amazon.CloudWatch.EMF.IntegrationTests/Amazon.CloudWatch.EMF.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/tests/Amazon.CloudWatch.EMF.Tests/Amazon.CloudWatch.EMF.Tests.csproj
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Amazon.CloudWatch.EMF.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>


### PR DESCRIPTION
*Issue:* Build is failing

*Description of changes:*

Updated the dotnet version to 6.0 for '~/tests' folder as error logs of failed build mentions to upgrade the version. 

> Testhost process for source(s) '/codebuild/output/src309287009/src/github.com/awslabs/aws-embedded-metrics-dotnet/tests/Amazon.CloudWatch.EMF.Tests/bin/Debug/netcoreapp3.1/Amazon.CloudWatch.EMF.Tests.dll' exited with error: You must install or update .NET to run this application.
> App: /root/.nuget/packages/microsoft.testplatform.testhost/16.7.1/lib/netcoreapp2.1/testhost.dll
> Architecture: x64
> Framework: 'Microsoft.NETCore.App', version '3.1.0' (x64)
> .NET location: /root/.dotnet/
> The following frameworks were found:
> 6.0.6 at [/root/.dotnet/shared/Microsoft.NETCore.App]
> 6.0.11 at [/root/.dotnet/shared/Microsoft.NETCore.App]
> Learn about framework resolution:
> https://aka.ms/dotnet/app-launch-failed
> To install missing framework, download:
> https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.1.0&arch=x64&rid=amzn.2-x64
> Please check the diagnostic logs for more information.
> Test Run Aborted.

> Testhost process for source(s) '/codebuild/output/src961617752/src/github.com/awslabs/aws-embedded-metrics-dotnet/tests/Amazon.CloudWatch.EMF.IntegrationTests/bin/Debug/netcoreapp3.1/Amazon.CloudWatch.EMF.IntegrationTests.dll' exited with error: You must install or update .NET to run this application.
> App: /root/.nuget/packages/microsoft.testplatform.testhost/16.7.1/lib/netcoreapp2.1/testhost.dll
> Architecture: x64
> Framework: 'Microsoft.NETCore.App', version '3.1.0' (x64)
> .NET location: /root/.dotnet/
> The following frameworks were found:
> 6.0.6 at [/root/.dotnet/shared/Microsoft.NETCore.App]
> 6.0.11 at [/root/.dotnet/shared/Microsoft.NETCore.App]
> Learn about framework resolution:
> https://aka.ms/dotnet/app-launch-failed
> To install missing framework, download:
> https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.1.0&arch=x64&rid=amzn.2-x64
> Please check the diagnostic logs for more information.
> Test Run Aborted.
> [Container] 2022/11/14 02:17:49 Command did not exit successfully dotnet test exit status 1
> [Container] 2022/11/14 02:17:49 Phase complete: BUILD State: FAILED

Also updated the version in Canary test as we are using dotnet 6.0 in buildspec.canary.yml file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
