### PR TITLE
Fix canary's heap usage to avoid system crash

### DIFF
--- a/src/Amazon.CloudWatch.EMF/Environment/EnvironmentProvider.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/EnvironmentProvider.cs
@@ -58,6 +58,14 @@ namespace Amazon.CloudWatch.EMF.Environment
             return new DefaultEnvironment(_configuration, _loggerFactory);
         }
 
+        /// <summary>
+        /// A helper method to clean the cached environment in tests.
+        /// </summary>
+        internal void CleanResolvedEnvironment()
+        {
+            _cachedEnvironment = null;
+        }
+
         private IEnvironment GetEnvironmentFromConfig()
         {
             switch (_configuration.EnvironmentOverride)

--- a/src/Amazon.CloudWatch.EMF/Environment/EnvironmentProvider.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/EnvironmentProvider.cs
@@ -14,7 +14,7 @@ namespace Amazon.CloudWatch.EMF.Environment
         private readonly IResourceFetcher _resourceFetcher;
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger<ECSEnvironment> _logger;
-        private IEnvironment _cachedEnvironment;
+        private static IEnvironment _cachedEnvironment;
 
         public EnvironmentProvider(IConfiguration configuration, IResourceFetcher resourceFetcher)
             : this(configuration, resourceFetcher, NullLoggerFactory.Instance)

--- a/tests/Amazon.CloudWatch.EMF.Canary/Amazon.CloudWatch.EMF.Canary.csproj
+++ b/tests/Amazon.CloudWatch.EMF.Canary/Amazon.CloudWatch.EMF.Canary.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Amazon.CloudWatch.EMF.Canary/Amazon.CloudWatch.EMF.Canary.csproj
+++ b/tests/Amazon.CloudWatch.EMF.Canary/Amazon.CloudWatch.EMF.Canary.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Amazon.CloudWatch.EMF.Canary/Dockerfile
+++ b/tests/Amazon.CloudWatch.EMF.Canary/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 COPY bin/Release/net6.0/publish/ App/
 WORKDIR /App
 ENTRYPOINT ["dotnet", "Amazon.CloudWatch.EMF.Canary.dll"]

--- a/tests/Amazon.CloudWatch.EMF.Canary/Dockerfile
+++ b/tests/Amazon.CloudWatch.EMF.Canary/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
-COPY bin/Release/netcoreapp3.1/publish/ App/
+FROM mcr.microsoft.com/dotnet/core/aspnet:6.0
+COPY bin/Release/net6.0/publish/ App/
 WORKDIR /App
 ENTRYPOINT ["dotnet", "Amazon.CloudWatch.EMF.Canary.dll"]

--- a/tests/Amazon.CloudWatch.EMF.Tests/Environment/EnvironmentProviderTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Environment/EnvironmentProviderTests.cs
@@ -4,11 +4,19 @@ using AutoFixture;
 using AutoFixture.AutoNSubstitute;
 using NSubstitute;
 using Xunit;
+using System;
 
 namespace Amazon.CloudWatch.EMF.Tests.Environment
 {
-    public class EnvironmentProviderTests
+    public class EnvironmentProviderTests: IDisposable
     {
+        
+        private EnvironmentProvider environmentProvider;
+
+        public void Dispose(){
+            environmentProvider.CleanResolvedEnvironment();
+        }
+
         [Fact]
         public void ResolveEnvironment_ReturnCachedEnv()
         {
@@ -17,9 +25,8 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             var configuration = fixture.Create<IConfiguration>();
             configuration.EnvironmentOverride.Returns(Environments.Local);
             var resourceFetcher = fixture.Create<IResourceFetcher>();
-            var environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
-            environmentProvider.CleanResolvedEnvironment();
-
+            environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
+            
             //Act
             var environment = environmentProvider.ResolveEnvironment();
             var environmentCache = environmentProvider.ResolveEnvironment();
@@ -36,9 +43,8 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             var configuration = fixture.Create<IConfiguration>();
             configuration.EnvironmentOverride.Returns(Environments.Lambda);
             var resourceFetcher = fixture.Create<IResourceFetcher>();
-            var environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
-            environmentProvider.CleanResolvedEnvironment();
-
+            environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
+            
             //Act
             var environment = environmentProvider.ResolveEnvironment();
 
@@ -54,9 +60,8 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             var configuration = fixture.Create<IConfiguration>();
             configuration.EnvironmentOverride.Returns(Environments.Local);
             var resourceFetcher = fixture.Create<IResourceFetcher>();
-            var environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
-            environmentProvider.CleanResolvedEnvironment();
-
+            environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
+            
             //Act
             var environment = environmentProvider.ResolveEnvironment();
 
@@ -72,9 +77,8 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             var configuration = fixture.Create<IConfiguration>();
             configuration.EnvironmentOverride.Returns(Environments.EC2);
             var resourceFetcher = fixture.Create<IResourceFetcher>();
-            var environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
-            environmentProvider.CleanResolvedEnvironment();
-
+            environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
+            
             //Act
             var environment = environmentProvider.ResolveEnvironment();
 
@@ -90,9 +94,8 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             var configuration = fixture.Create<IConfiguration>();
             configuration.EnvironmentOverride.Returns(Environments.ECS);
             var resourceFetcher = fixture.Create<IResourceFetcher>();
-            var environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
-            environmentProvider.CleanResolvedEnvironment();
-
+            environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
+            
             //Act
             var environment = environmentProvider.ResolveEnvironment();
 

--- a/tests/Amazon.CloudWatch.EMF.Tests/Environment/EnvironmentProviderTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Environment/EnvironmentProviderTests.cs
@@ -18,6 +18,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             configuration.EnvironmentOverride.Returns(Environments.Local);
             var resourceFetcher = fixture.Create<IResourceFetcher>();
             var environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
+            environmentProvider.CleanResolvedEnvironment();
 
             //Act
             var environment = environmentProvider.ResolveEnvironment();
@@ -36,6 +37,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             configuration.EnvironmentOverride.Returns(Environments.Lambda);
             var resourceFetcher = fixture.Create<IResourceFetcher>();
             var environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
+            environmentProvider.CleanResolvedEnvironment();
 
             //Act
             var environment = environmentProvider.ResolveEnvironment();
@@ -53,6 +55,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             configuration.EnvironmentOverride.Returns(Environments.Local);
             var resourceFetcher = fixture.Create<IResourceFetcher>();
             var environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
+            environmentProvider.CleanResolvedEnvironment();
 
             //Act
             var environment = environmentProvider.ResolveEnvironment();
@@ -70,6 +73,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             configuration.EnvironmentOverride.Returns(Environments.EC2);
             var resourceFetcher = fixture.Create<IResourceFetcher>();
             var environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
+            environmentProvider.CleanResolvedEnvironment();
 
             //Act
             var environment = environmentProvider.ResolveEnvironment();
@@ -87,6 +91,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             configuration.EnvironmentOverride.Returns(Environments.ECS);
             var resourceFetcher = fixture.Create<IResourceFetcher>();
             var environmentProvider = new EnvironmentProvider(configuration, resourceFetcher);
+            environmentProvider.CleanResolvedEnvironment();
 
             //Act
             var environment = environmentProvider.ResolveEnvironment();


### PR DESCRIPTION
*Issue #40*

*Description of changes:*

When we create a new instance of MetricsLogger in the Canary, the program is not able to detect the existing connection and makes a new connection every time. Hence, it reconnects after every packet it sends and ends up creating multiple open ports. The reason behind this is the variable __cachedEnvironment_ is not static, and hence, it is not shared across all instances of the class. After making this variable static, when a new logger is created, it will be able to find the existing connection (if any) and won't make a new connection.

Also changed docker image for fixing the build pipeline failure. And finally, as tests run in parallel for dotnet, making the environment static was leading to some test failures. Hence, cleaned the environment after every tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
