### PR TITLE
Add support for high-resolution metrics in EMF

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ using (var logger = new MetricsLogger()) {
     var dimensionSet = new DimensionSet();
     dimensionSet.AddDimension("Service", "aggregator");
     logger.SetDimensions(dimensionSet);
+    // Defaults to StorageResolution.Standard
     logger.PutMetric("ProcessingLatency", 100, Unit.MILLISECONDS);
+    // Can override to StorageResolution.High
+    logger.PutMetric("Memory.HeapUsed", "1600424.0", Unit.BYTES, StorageResolution.HIGH);
     logger.PutProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8");
+    
 }
 ```
 
@@ -65,7 +69,10 @@ using (var logger = new MetricsLogger()) {
     var dimensionSet = new DimensionSet();
     dimensionSet.AddDimension("Service", "aggregator");
     logger.SetDimensions(dimensionSet);
+    // Defaults to StorageResolution.Standard
     logger.PutMetric("ProcessingLatency", 100, Unit.MILLISECONDS);
+    // Can override to StorageResolution.High
+    logger.PutMetric("Memory.HeapUsed", "1600424.0", Unit.BYTES, StorageResolution.HIGH); 
     logger.PutProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8");
 }
 
@@ -155,19 +162,23 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 
 ### MetricsLogger
 
-The `MetricsLogger` is the interface you will use to publish embedded metrics.
+The `MetricsLogger` is the interface you will use to publish embedded metrics. By Default StorageResolution is StandardResolution.
 
-- MetricsLogger **PutMetric**(string key, double value, Unit unit)
-- MetricsLogger **PutMetric**(string key, double value)
+- MetricsLogger **PutMetric**(string key, double value, Unit unit, StorageResolution storageResolution)
+- MetricsLogger **PutMetric**(string key, double value, StorageResolution storageResolution)
 
-Adds a new metric to the current logger context. Multiple metrics using the same key will be appended to an array of values. The Embedded Metric Format supports a maxumum of 100 metrics per key.
+Adds a new metric to the current logger context. Multiple metrics using the same key will be appended to an array of values. Multiple metrics cannot have same key but different storage resolution. Same metric cannot have different storage resolutions otherwise a `InvalidMetricException` will be thrown. The Embedded Metric Format supports a maxumum of 100 metrics per key.
 
 Metrics must meet CloudWatch Metrics requirements, otherwise a `InvalidMetricException` will be thrown. See [MetricDatum](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html) for valid values.
 
 Example:
 
 ```c#
+// Standard Resolution Example
 metrics.PutMetric("ProcessingLatency", 101, Unit.MILLISECONDS);
+
+// High Resolution Example
+logger.PutMetric("Memory.HeapUsed", "1600424.0", Unit.BYTES, StorageResolution.HIGH);
 ```
 
 - MetricsLogger **PutProperty**(string key, object value)

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Adds a new metric to the current logger context. Multiple metrics using the same
 Metrics must meet CloudWatch Metrics requirements, otherwise a `InvalidMetricException` will be thrown. See [MetricDatum](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html) for valid values.
 
 ##### Storage Resolution.
-An OPTIONAL value representing the storage resolution for the corresponding metric. Setting this to High specifies this metric as a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second. Setting this to 60 specifies this metric as a Standard-resolution metric, which CloudWatch stores at 1-minute resolution. If a value is not provided, then a default value of Standard is assumed. See [Cloud Watch High-Resolution metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics)
+An OPTIONAL value representing the storage resolution for the corresponding metric. Setting this to `High` specifies this metric as a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second. Setting this to `Standard` specifies this metric as a standard-resolution metric, which CloudWatch stores at 1-minute resolution. If a value is not provided, then a default value of `Standard` is assumed. See [Cloud Watch High-Resolution metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics)
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ using (var logger = new MetricsLogger()) {
     var dimensionSet = new DimensionSet();
     dimensionSet.AddDimension("Service", "aggregator");
     logger.SetDimensions(dimensionSet);
-    // Defaults to StorageResolution.Standard
-    logger.PutMetric("ProcessingLatency", 100, Unit.MILLISECONDS);
-    // Can override to StorageResolution.High
+    logger.PutMetric("ProcessingLatency", 100, Unit.MILLISECONDS,StorageResolution.STANDARD);
     logger.PutMetric("Memory.HeapUsed", "1600424.0", Unit.BYTES, StorageResolution.HIGH);
     logger.PutProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8");
     
@@ -69,9 +67,7 @@ using (var logger = new MetricsLogger()) {
     var dimensionSet = new DimensionSet();
     dimensionSet.AddDimension("Service", "aggregator");
     logger.SetDimensions(dimensionSet);
-    // Defaults to StorageResolution.Standard
     logger.PutMetric("ProcessingLatency", 100, Unit.MILLISECONDS);
-    // Can override to StorageResolution.High
     logger.PutMetric("Memory.HeapUsed", "1600424.0", Unit.BYTES, StorageResolution.HIGH); 
     logger.PutProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8");
 }
@@ -162,14 +158,19 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 
 ### MetricsLogger
 
-The `MetricsLogger` is the interface you will use to publish embedded metrics. By Default StorageResolution is StandardResolution.
+The `MetricsLogger` is the interface you will use to publish embedded metrics. 
 
-- MetricsLogger **PutMetric**(string key, double value, Unit unit, StorageResolution storageResolution)
+- MetricsLogger **PutMetric**(string key, double value)
+- MetricsLogger **PutMetric**(string key, double value, Unit unit)
 - MetricsLogger **PutMetric**(string key, double value, StorageResolution storageResolution)
+- MetricsLogger **PutMetric**(string key, double value, Unit unit, StorageResolution storageResolution)
 
-Adds a new metric to the current logger context. Multiple metrics using the same key will be appended to an array of values. Multiple metrics cannot have same key but different storage resolution. Same metric cannot have different storage resolutions otherwise a `InvalidMetricException` will be thrown. The Embedded Metric Format supports a maxumum of 100 metrics per key.
+Adds a new metric to the current logger context. Multiple metrics using the same key will be appended to an array of values. Multiple metrics cannot have the same key but different storage resolutions. Same metric cannot have different storage resolutions otherwise a `InvalidMetricException` will be thrown. The Embedded Metric Format supports a maxumum of 100 metrics per key.
 
 Metrics must meet CloudWatch Metrics requirements, otherwise a `InvalidMetricException` will be thrown. See [MetricDatum](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html) for valid values.
+
+##### Storage Resolution.
+An OPTIONAL value representing the storage resolution for the corresponding metric. Setting this to High specifies this metric as a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second. Setting this to 60 specifies this metric as a Standard-resolution metric, which CloudWatch stores at 1-minute resolution. If a value is not provided, then a default value of Standard is assumed. See [Cloud Watch High-Resolution metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics)
 
 Example:
 

--- a/examples/Amazon.CloudWatch.EMF.Examples.ConsoleApp/Program.cs
+++ b/examples/Amazon.CloudWatch.EMF.Examples.ConsoleApp/Program.cs
@@ -38,7 +38,6 @@ namespace Amazon.CloudWatch.EMF.ConsoleApp
             }
 
             logger.LogInformation("Shutting down");
-            
             environment.Sink.Shutdown().Wait(TimeSpan.FromSeconds(120));
         }
 
@@ -56,7 +55,7 @@ namespace Amazon.CloudWatch.EMF.ConsoleApp
             metrics.PutMetric("ProcessingLatency", 99, Unit.MILLISECONDS);
 
             // High Resolution
-            metrics.PutMetric("Memory.HeapUsed", GC.GetTotalMemory(false), Unit.BYTES,StorageResolution.HIGH);
+            metrics.PutMetric("Memory.HeapUsed", GC.GetTotalMemory(false), Unit.BYTES, StorageResolution.HIGH);
 
             metrics.PutMetric("Count", 3, Unit.COUNT);
             metrics.PutProperty("AccountId", "123456789");

--- a/examples/Amazon.CloudWatch.EMF.Examples.ConsoleApp/Program.cs
+++ b/examples/Amazon.CloudWatch.EMF.Examples.ConsoleApp/Program.cs
@@ -50,9 +50,14 @@ namespace Amazon.CloudWatch.EMF.ConsoleApp
             dimensionSet.AddDimension("Region", "us-west-2");
             metrics.SetDimensions(dimensionSet);
 
+            // Standard Resolutions
             metrics.PutMetric("ProcessingLatency", 101, Unit.MILLISECONDS);
             metrics.PutMetric("ProcessingLatency", 100, Unit.MILLISECONDS);
             metrics.PutMetric("ProcessingLatency", 99, Unit.MILLISECONDS);
+
+            // High Resolution
+            metrics.PutMetric("Memory.HeapUsed", GC.GetTotalMemory(false), Unit.BYTES,StorageResolution.HIGH);
+
             metrics.PutMetric("Count", 3, Unit.COUNT);
             metrics.PutProperty("AccountId", "123456789");
             metrics.PutProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8");

--- a/examples/Amazon.CloudWatch.EMF.Examples.Lambda/Function.cs
+++ b/examples/Amazon.CloudWatch.EMF.Examples.Lambda/Function.cs
@@ -32,6 +32,7 @@ namespace Amazon.CloudWatch.EMF.Lambda
             logger.PutMetric("ProcessingLatency", 100, Unit.MILLISECONDS);
             logger.PutMetric("ProcessingLatency", 99, Unit.MILLISECONDS);
             logger.PutMetric("Count", 3, Unit.COUNT);
+            logger.PutMetric("InputPayloadSize", System.Text.ASCIIEncoding.ASCII.GetByteCount(input), Unit.BYTES, StorageResolution.HIGH);
             logger.PutProperty("AccountId", "123456789");
             logger.PutProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8");
             logger.PutProperty("DeviceId", "61270781-c6ac-46f1-baf7-22c808af8162");

--- a/examples/Amazon.CloudWatch.EMF.Examples.Lambda/Function.cs
+++ b/examples/Amazon.CloudWatch.EMF.Examples.Lambda/Function.cs
@@ -4,6 +4,7 @@ using Amazon.CloudWatch.EMF.Environment;
 using Amazon.CloudWatch.EMF.Logger;
 using Amazon.CloudWatch.EMF.Model;
 using Amazon.Lambda.Core;
+using System.Text;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
@@ -32,7 +33,7 @@ namespace Amazon.CloudWatch.EMF.Lambda
             logger.PutMetric("ProcessingLatency", 100, Unit.MILLISECONDS);
             logger.PutMetric("ProcessingLatency", 99, Unit.MILLISECONDS);
             logger.PutMetric("Count", 3, Unit.COUNT);
-            logger.PutMetric("InputPayloadSize", System.Text.ASCIIEncoding.ASCII.GetByteCount(input), Unit.BYTES, StorageResolution.HIGH);
+            logger.PutMetric("InputPayloadSize", ASCIIEncoding.ASCII.GetByteCount(input), Unit.BYTES, StorageResolution.HIGH);
             logger.PutProperty("AccountId", "123456789");
             logger.PutProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8");
             logger.PutProperty("DeviceId", "61270781-c6ac-46f1-baf7-22c808af8162");

--- a/examples/Amazon.CloudWatch.EMF.Examples.Web/Controllers/WeatherForecastController.cs
+++ b/examples/Amazon.CloudWatch.EMF.Examples.Web/Controllers/WeatherForecastController.cs
@@ -23,7 +23,7 @@ namespace Amazon.CloudWatch.EMF.Web.Controllers
         private readonly IMetricsLogger _metrics;
 
         public WeatherForecastController(
-            ILogger<WeatherForecastController> logger, 
+            ILogger<WeatherForecastController> logger,
             IMetricsLogger metrics)
         {
             _logger = logger;
@@ -36,8 +36,10 @@ namespace Amazon.CloudWatch.EMF.Web.Controllers
             Thread.Sleep(100);
             var rng = new Random();
             var temperature = rng.Next(-20, 55);
+            var WindSpeed = rng.Next(10, 100);
 
             _metrics.PutMetric("Temperature", temperature, Unit.NONE);
+            _metrics.PutMetric("WindSpeed", WindSpeed, Unit.NONE, StorageResolution.HIGH);
 
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {

--- a/examples/Amazon.CloudWatch.EMF.Examples.Web/Startup.cs
+++ b/examples/Amazon.CloudWatch.EMF.Examples.Web/Startup.cs
@@ -9,7 +9,7 @@ namespace Amazon.CloudWatch.EMF.Web
     public class Startup
     {
         public Startup(
-            IConfiguration configuration, 
+            IConfiguration configuration,
             IHostEnvironment hostEnv)
         {
             Configuration = configuration;

--- a/src/Amazon.CloudWatch.EMF/Config/ConfigurationKeys.cs
+++ b/src/Amazon.CloudWatch.EMF/Config/ConfigurationKeys.cs
@@ -2,13 +2,13 @@ namespace Amazon.CloudWatch.EMF.Config
 {
     public class ConfigurationKeys
     {
-        public const string ENV_VAR_PREFIX = "AWS_EMF";
-        public const string SERVICE_NAME = "SERVICE_NAME";
-        public const string SERVICE_TYPE = "SERVICE_TYPE";
-        public const string LOG_GROUP_NAME = "LOG_GROUP_NAME";
-        public const string LOG_STREAM_NAME = "LOG_STREAM_NAME";
-        public const string AGENT_ENDPOINT = "AGENT_ENDPOINT";
-        public const string AGENT_BUFFER_SIZE = "AGENT_BUFFER_SIZE";
-        public const string ENVIRONMENT_OVERRIDE = "ENVIRONMENT";
+        public const string EnvVarPrefix = "AWS_EMF";
+        public const string ServiceName = "SERVICE_NAME";
+        public const string ServiceType = "SERVICE_TYPE";
+        public const string LogGroupName = "LOG_GROUP_NAME";
+        public const string LogStreamName = "LOG_STREAM_NAME";
+        public const string AgentEndpoint = "AGENT_ENDPOINT";
+        public const string AgentBufferSize = "AGENT_BUFFER_SIZE";
+        public const string EnvironmentOverride = "ENVIRONMENT";
     }
 }

--- a/src/Amazon.CloudWatch.EMF/Config/EnvironmentConfigurationProvider.cs
+++ b/src/Amazon.CloudWatch.EMF/Config/EnvironmentConfigurationProvider.cs
@@ -16,16 +16,16 @@ namespace Amazon.CloudWatch.EMF.Config
             get
             {
                 var bufferSize = Int32.TryParse(
-                        GetEnvVar(ConfigurationKeys.AGENT_BUFFER_SIZE), out var parsedBufferSize)
+                        GetEnvVar(ConfigurationKeys.AgentBufferSize), out var parsedBufferSize)
                             ? parsedBufferSize
                             : Configuration.DEFAULT_AGENT_BUFFER_SIZE;
 
                 return _config ??= new Configuration(
-                    GetEnvVar(ConfigurationKeys.SERVICE_NAME),
-                    GetEnvVar(ConfigurationKeys.SERVICE_TYPE),
-                    GetEnvVar(ConfigurationKeys.LOG_GROUP_NAME),
-                    GetEnvVar(ConfigurationKeys.LOG_STREAM_NAME),
-                    GetEnvVar(ConfigurationKeys.AGENT_ENDPOINT),
+                    GetEnvVar(ConfigurationKeys.ServiceName),
+                    GetEnvVar(ConfigurationKeys.ServiceType),
+                    GetEnvVar(ConfigurationKeys.LogGroupName),
+                    GetEnvVar(ConfigurationKeys.LogStreamName),
+                    GetEnvVar(ConfigurationKeys.AgentEndpoint),
                     bufferSize,
                     GetEnvironmentOverride());
             }
@@ -34,7 +34,7 @@ namespace Amazon.CloudWatch.EMF.Config
 
         private static Environments GetEnvironmentOverride()
         {
-            var environmentName = GetEnvVar(ConfigurationKeys.ENVIRONMENT_OVERRIDE);
+            var environmentName = GetEnvVar(ConfigurationKeys.EnvironmentOverride);
             if (string.IsNullOrEmpty(environmentName))
             {
                 return Environments.Unknown;
@@ -52,7 +52,7 @@ namespace Amazon.CloudWatch.EMF.Config
 
         private static string GetEnvVar(string key)
         {
-            var name = string.Join(string.Empty, ConfigurationKeys.ENV_VAR_PREFIX, "_", key);
+            var name = string.Join(string.Empty, ConfigurationKeys.EnvVarPrefix, "_", key);
             return EnvUtils.GetEnv(name);
         }
     }

--- a/src/Amazon.CloudWatch.EMF/Constants.cs
+++ b/src/Amazon.CloudWatch.EMF/Constants.cs
@@ -2,19 +2,19 @@ namespace Amazon.CloudWatch.EMF
 {
     public class Constants
     {
-        public const int MAX_DIMENSION_SET_SIZE = 30;
-        public const int MAX_DIMENSION_NAME_LENGTH = 250;
-        public const int MAX_DIMENSION_VALUE_LENGTH = 1024;
-        public const int MAX_METRIC_NAME_LENGTH = 1024;
-        public const int MAX_NAMESPACE_LENGTH = 256;
-        public const string VALID_NAMESPACE_REGEX = "^[a-zA-Z0-9._#:/-]+$";
+        public const int MaxDimensionSetSize = 30;
+        public const int MaxDimensionNameLength = 250;
+        public const int MaxDimensionValueLength = 1024;
+        public const int MaxMetricNameLength = 1024;
+        public const int MaxNamespaceLength = 256;
+        public const string ValidNamespaceRegex = "^[a-zA-Z0-9._#:/-]+$";
 
-        public const int DEFAULT_AGENT_PORT = 25888;
+        public const int DefaultAgentPort = 25888;
 
-        public const string UNKNOWN = "Unknown";
+        public const string Unknown = "Unknown";
 
-        public const int MAX_METRICS_PER_EVENT = 100;
+        public const int MaxMetricsPerEvent = 100;
 
-        public const string DEFAULT_NAMESPACE = "aws-embedded-metrics";
+        public const string DefaultNamespace = "aws-embedded-metrics";
     }
 }

--- a/src/Amazon.CloudWatch.EMF/Environment/AgentBasedEnvironment.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/AgentBasedEnvironment.cs
@@ -18,9 +18,9 @@ namespace Amazon.CloudWatch.EMF.Environment
             _loggerFactory = loggerFactory;
         }
 
-        public virtual string Name => !string.IsNullOrEmpty(_configuration.ServiceName) ? _configuration.ServiceName : Constants.UNKNOWN;
+        public virtual string Name => !string.IsNullOrEmpty(_configuration.ServiceName) ? _configuration.ServiceName : Constants.Unknown;
 
-        public virtual string Type => !string.IsNullOrEmpty(_configuration.ServiceType) ? _configuration.ServiceType : Constants.UNKNOWN;
+        public virtual string Type => !string.IsNullOrEmpty(_configuration.ServiceType) ? _configuration.ServiceType : Constants.Unknown;
 
         public virtual string LogGroupName => !string.IsNullOrEmpty(_configuration.LogGroupName) ? _configuration.LogGroupName : Name + "_metrics";
 

--- a/src/Amazon.CloudWatch.EMF/Environment/AgentBasedEnvironment.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/AgentBasedEnvironment.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Amazon.CloudWatch.EMF.Environment
 {
-    public abstract class AgentBasedEnvironment : IEnvironment
+public abstract class AgentBasedEnvironment : IEnvironment
     {
         protected readonly IConfiguration _configuration;
         private readonly ILoggerFactory _loggerFactory;

--- a/src/Amazon.CloudWatch.EMF/Environment/AgentBasedEnvironment.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/AgentBasedEnvironment.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Amazon.CloudWatch.EMF.Environment
 {
-public abstract class AgentBasedEnvironment : IEnvironment
+    public abstract class AgentBasedEnvironment : IEnvironment
     {
         protected readonly IConfiguration _configuration;
         private readonly ILoggerFactory _loggerFactory;

--- a/src/Amazon.CloudWatch.EMF/Environment/EC2Environment.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/EC2Environment.cs
@@ -103,7 +103,7 @@ namespace Amazon.CloudWatch.EMF.Environment
                     return CFN_EC2_TYPE;
                 }
 
-                return Constants.UNKNOWN;
+                return Constants.Unknown;
             }
         }
 

--- a/src/Amazon.CloudWatch.EMF/Environment/ECSEnvironment.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/ECSEnvironment.cs
@@ -78,7 +78,7 @@ namespace Amazon.CloudWatch.EMF.Environment
                     return _ecsMetadata.FormattedImageName;
                 }
 
-                return Constants.UNKNOWN;
+                return Constants.Unknown;
             }
         }
 
@@ -148,7 +148,7 @@ namespace Amazon.CloudWatch.EMF.Environment
 
             if (fluentHost == null || !string.IsNullOrEmpty(_configuration.AgentEndPoint)) return;
 
-            _fluentBitEndpoint = string.Format("tcp://%s:%d", fluentHost, Constants.DEFAULT_AGENT_PORT);
+            _fluentBitEndpoint = string.Format("tcp://%s:%d", fluentHost, Constants.DefaultAgentPort);
             _configuration.AgentEndPoint = _fluentBitEndpoint;
 
             _logger.LogInformation("Using FluentBit configuration. Endpoint: {}", _fluentBitEndpoint);

--- a/src/Amazon.CloudWatch.EMF/Environment/LocalEnvironment.cs
+++ b/src/Amazon.CloudWatch.EMF/Environment/LocalEnvironment.cs
@@ -22,9 +22,9 @@ namespace Amazon.CloudWatch.EMF.Environment
             return false;
         }
 
-        public string Name => !string.IsNullOrEmpty(_config.ServiceName) ? _config.ServiceName : Constants.UNKNOWN;
+        public string Name => !string.IsNullOrEmpty(_config.ServiceName) ? _config.ServiceName : Constants.Unknown;
 
-        public string Type => !string.IsNullOrEmpty(_config.ServiceType) ? _config.ServiceType : Constants.UNKNOWN;
+        public string Type => !string.IsNullOrEmpty(_config.ServiceType) ? _config.ServiceType : Constants.Unknown;
 
         public string LogGroupName => !string.IsNullOrEmpty(_config.LogGroupName) ? _config.LogGroupName : Name + "_metrics";
 

--- a/src/Amazon.CloudWatch.EMF/Exception/DimensionSetExceededException.cs
+++ b/src/Amazon.CloudWatch.EMF/Exception/DimensionSetExceededException.cs
@@ -5,7 +5,7 @@ namespace Amazon.CloudWatch.EMF
     public class DimensionSetExceededException : Exception
     {
         public DimensionSetExceededException()
-            : base("Maximum number of dimensions per dimension set allowed are " + Constants.MAX_DIMENSION_SET_SIZE +
+            : base("Maximum number of dimensions per dimension set allowed are " + Constants.MaxDimensionSetSize +
                    ". Account for default dimensions if not using SetDimensions.")
         {
         }

--- a/src/Amazon.CloudWatch.EMF/Logger/IMetricsLogger.cs
+++ b/src/Amazon.CloudWatch.EMF/Logger/IMetricsLogger.cs
@@ -15,9 +15,9 @@ namespace Amazon.CloudWatch.EMF.Logger
 
         public MetricsLogger SetDimensions(params DimensionSet[] dimensionSets);
 
-        public MetricsLogger PutMetric(string key, double value, Unit unit);
+        public MetricsLogger PutMetric(string key, double value, Unit unit, StorageResolution storageResolution = StorageResolution.STANDARD);
 
-        public MetricsLogger PutMetric(string key, double value);
+        public MetricsLogger PutMetric(string key, double value, StorageResolution storageResolution = StorageResolution.STANDARD);
 
         public MetricsLogger PutMetadata(string key, object value);
 

--- a/src/Amazon.CloudWatch.EMF/Logger/MetricsLogger.cs
+++ b/src/Amazon.CloudWatch.EMF/Logger/MetricsLogger.cs
@@ -166,7 +166,7 @@ namespace Amazon.CloudWatch.EMF.Logger
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
         /// <param name="unit">the unit of the metric value</param>
-        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Default Set to Standard Storage Resolution</param>
         /// <returns>the current logger</returns>
         public MetricsLogger PutMetric(string key, double value, Unit unit, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
@@ -181,7 +181,7 @@ namespace Amazon.CloudWatch.EMF.Logger
         /// </summary>
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
-        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Default Set to Standard Storage Resolution</param>
         /// <returns>the current logger</returns>
         public MetricsLogger PutMetric(string key, double value, StorageResolution storageResolution = StorageResolution.STANDARD)
         {

--- a/src/Amazon.CloudWatch.EMF/Logger/MetricsLogger.cs
+++ b/src/Amazon.CloudWatch.EMF/Logger/MetricsLogger.cs
@@ -166,7 +166,7 @@ namespace Amazon.CloudWatch.EMF.Logger
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
         /// <param name="unit">the unit of the metric value</param>
-        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution with 60</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution</param>
         /// <returns>the current logger</returns>
         public MetricsLogger PutMetric(string key, double value, Unit unit, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
@@ -181,7 +181,7 @@ namespace Amazon.CloudWatch.EMF.Logger
         /// </summary>
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
-        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution with 60</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution</param>
         /// <returns>the current logger</returns>
         public MetricsLogger PutMetric(string key, double value, StorageResolution storageResolution = StorageResolution.STANDARD)
         {

--- a/src/Amazon.CloudWatch.EMF/Logger/MetricsLogger.cs
+++ b/src/Amazon.CloudWatch.EMF/Logger/MetricsLogger.cs
@@ -166,7 +166,7 @@ namespace Amazon.CloudWatch.EMF.Logger
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
         /// <param name="unit">the unit of the metric value</param>
-        /// <param name="storageResolution">the storage resolution of the metric. Default Set to Standard Storage Resolution</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Defaults to Standard Storage Resolution</param>
         /// <returns>the current logger</returns>
         public MetricsLogger PutMetric(string key, double value, Unit unit, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
@@ -181,7 +181,7 @@ namespace Amazon.CloudWatch.EMF.Logger
         /// </summary>
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
-        /// <param name="storageResolution">the storage resolution of the metric. Default Set to Standard Storage Resolution</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Defaults to Standard Storage Resolution</param>
         /// <returns>the current logger</returns>
         public MetricsLogger PutMetric(string key, double value, StorageResolution storageResolution = StorageResolution.STANDARD)
         {

--- a/src/Amazon.CloudWatch.EMF/Logger/MetricsLogger.cs
+++ b/src/Amazon.CloudWatch.EMF/Logger/MetricsLogger.cs
@@ -166,10 +166,11 @@ namespace Amazon.CloudWatch.EMF.Logger
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
         /// <param name="unit">the unit of the metric value</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution with 60</param>
         /// <returns>the current logger</returns>
-        public MetricsLogger PutMetric(string key, double value, Unit unit)
+        public MetricsLogger PutMetric(string key, double value, Unit unit, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
-            _context.PutMetric(key, value, unit);
+            _context.PutMetric(key, value, unit, storageResolution);
             return this;
         }
 
@@ -180,10 +181,11 @@ namespace Amazon.CloudWatch.EMF.Logger
         /// </summary>
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution with 60</param>
         /// <returns>the current logger</returns>
-        public MetricsLogger PutMetric(string key, double value)
+        public MetricsLogger PutMetric(string key, double value, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
-            _context.PutMetric(key, value, Unit.NONE);
+            _context.PutMetric(key, value, Unit.NONE, storageResolution);
             return this;
         }
 

--- a/src/Amazon.CloudWatch.EMF/Model/DimensionSet.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/DimensionSet.cs
@@ -34,7 +34,7 @@ namespace Amazon.CloudWatch.EMF.Model
         public void AddDimension(string key, string value)
         {
             Validator.ValidateDimensionSet(key, value);
-            if (Dimensions.Count >= Constants.MAX_DIMENSION_SET_SIZE)
+            if (Dimensions.Count >= Constants.MaxDimensionSetSize)
                 throw new DimensionSetExceededException();
 
             Dimensions[key] = value;
@@ -48,7 +48,7 @@ namespace Amazon.CloudWatch.EMF.Model
         public DimensionSet AddRange(DimensionSet other)
         {
             var mergedDimensionSetSize = other.DimensionKeys.Count + Dimensions.Count;
-            if (mergedDimensionSetSize > Constants.MAX_DIMENSION_SET_SIZE)
+            if (mergedDimensionSetSize > Constants.MaxDimensionSetSize)
                 throw new DimensionSetExceededException();
 
             foreach (var dimension in other?.Dimensions)

--- a/src/Amazon.CloudWatch.EMF/Model/MetricDefinition.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricDefinition.cs
@@ -5,23 +5,27 @@ namespace Amazon.CloudWatch.EMF.Model
 {
     public class MetricDefinition
     {
-        public MetricDefinition(string name) : this(name, Unit.NONE, new List<double>())
+        public MetricDefinition(string name, StorageResolution resolution = StorageResolution.STANDARD)
+            : this(name, Unit.NONE, new List<double>(), resolution)
         {
         }
 
-        public MetricDefinition(string name, double value) : this(name, Unit.NONE, new List<double> { value })
+        public MetricDefinition(string name, double value, StorageResolution resolution = StorageResolution.STANDARD)
+            : this(name, Unit.NONE, new List<double> { value }, resolution)
         {
         }
 
-        public MetricDefinition(string name, Unit unit, double value) : this(name, unit, new List<double> { value })
+        public MetricDefinition(string name, Unit unit, double value, StorageResolution resolution = StorageResolution.STANDARD)
+            : this(name, unit, new List<double> { value }, resolution)
         {
         }
 
-        public MetricDefinition(string name, Unit unit, List<double> values)
+        public MetricDefinition(string name, Unit unit, List<double> values, StorageResolution storageResolution)
         {
             Name = name;
             Unit = unit;
             Values = values;
+            StorageResolution = storageResolution;
         }
 
         public void AddValue(double value)
@@ -37,5 +41,16 @@ namespace Amazon.CloudWatch.EMF.Model
 
         [JsonProperty("Unit")]
         public Unit Unit { get; set; }
+
+        [JsonProperty("StorageResolution")]
+        public StorageResolution StorageResolution { get; set; }
+
+        // This property is used for serialization decision.
+        // Final property serialization will be ignored if set to StandardResolution.
+        public bool ShouldSerializeStorageResolution()
+        {
+            // don't serialize the StorageResolution property if StorageResolution is set to Standard
+            return StorageResolution != StorageResolution.STANDARD;
+        }
     }
 }

--- a/src/Amazon.CloudWatch.EMF/Model/MetricDefinition.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricDefinition.cs
@@ -6,21 +6,21 @@ namespace Amazon.CloudWatch.EMF.Model
     public class MetricDefinition
     {
         public MetricDefinition(string name, StorageResolution resolution = StorageResolution.STANDARD)
-            : this(name, Unit.NONE, new List<double>(), resolution)
+            : this(name, new List<double>(), Unit.NONE, resolution)
         {
         }
 
         public MetricDefinition(string name, double value, StorageResolution resolution = StorageResolution.STANDARD)
-            : this(name, Unit.NONE, new List<double> { value }, resolution)
+            : this(name, new List<double> { value }, Unit.NONE, resolution)
         {
         }
 
-        public MetricDefinition(string name, Unit unit, double value, StorageResolution resolution = StorageResolution.STANDARD)
-            : this(name, unit, new List<double> { value }, resolution)
+        public MetricDefinition(string name, double value, Unit unit, StorageResolution resolution = StorageResolution.STANDARD)
+            : this(name, new List<double> { value }, unit, resolution)
         {
         }
 
-        public MetricDefinition(string name, Unit unit, List<double> values, StorageResolution storageResolution)
+        public MetricDefinition(string name, List<double> values, Unit unit, StorageResolution storageResolution)
         {
             Name = name;
             Unit = unit;

--- a/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
@@ -48,7 +48,7 @@ namespace Amazon.CloudWatch.EMF.Model
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
         /// <param name="unit">the units of the metric</param>
-        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution with 60</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Defaults to Standard Resolution</param>
         internal void PutMetric(string key, double value, Unit unit, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
             var metric = _metrics.FirstOrDefault(m => m.Name == key);

--- a/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
@@ -15,7 +15,7 @@ namespace Amazon.CloudWatch.EMF.Model
 
         public MetricDirective()
         {
-            Namespace = Constants.DEFAULT_NAMESPACE;
+            Namespace = Constants.DefaultNamespace;
             _metrics = new List<MetricDefinition>();
             CustomDimensionSets = new List<DimensionSet>();
             DefaultDimensionSet = new DimensionSet();

--- a/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
@@ -58,7 +58,7 @@ namespace Amazon.CloudWatch.EMF.Model
             }
             else
             {
-                _metrics.Add(new MetricDefinition(key, unit, value, storageResolution));
+                _metrics.Add(new MetricDefinition(key, value, unit, storageResolution));
             }
         }
 

--- a/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricDirective.cs
@@ -35,9 +35,9 @@ namespace Amazon.CloudWatch.EMF.Model
 
         internal DimensionSet DefaultDimensionSet { get; set; }
 
-        internal void PutMetric(string key, double value)
+        internal void PutMetric(string key, double value, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
-            PutMetric(key, value, Unit.NONE);
+            PutMetric(key, value, Unit.NONE, storageResolution);
         }
 
         /// <summary>
@@ -45,10 +45,11 @@ namespace Amazon.CloudWatch.EMF.Model
         /// Adds the value an existing metric if one already exists with the specified key or
         /// adds a new metric if one with the specified key does not already exist.
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <param name="unit"></param>
-        internal void PutMetric(string key, double value, Unit unit)
+        /// <param name="key">the name of the metric</param>
+        /// <param name="value">the value of the metric</param>
+        /// <param name="unit">the units of the metric</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution with 60</param>
+        internal void PutMetric(string key, double value, Unit unit, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
             var metric = _metrics.FirstOrDefault(m => m.Name == key);
             if (metric != null)
@@ -57,7 +58,7 @@ namespace Amazon.CloudWatch.EMF.Model
             }
             else
             {
-                _metrics.Add(new MetricDefinition(key, unit, value));
+                _metrics.Add(new MetricDefinition(key, unit, value, storageResolution));
             }
         }
 

--- a/src/Amazon.CloudWatch.EMF/Model/MetricsContext.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricsContext.cs
@@ -110,14 +110,13 @@ namespace Amazon.CloudWatch.EMF.Model
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
         /// <param name="unit">the units of the metric</param>
-        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution with 60</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution</param>
         public void PutMetric(string key, double value, Unit unit, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
-            if (!_storageResolutionMetrics.ContainsKey(key))
-                _storageResolutionMetrics.TryAdd(key, storageResolution);
-
             Validator.ValidateMetric(key, value, storageResolution, _storageResolutionMetrics);
             _metricDirective.PutMetric(key, value, unit, storageResolution);
+            if (!_storageResolutionMetrics.ContainsKey(key))
+                _storageResolutionMetrics.TryAdd(key, storageResolution);
         }
 
         /// <summary>
@@ -131,7 +130,7 @@ namespace Amazon.CloudWatch.EMF.Model
         /// </example>
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
-         /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution with 60</param>
+         /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution</param>
         public void PutMetric(string key, double value, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
             PutMetric(key, value, Unit.NONE, storageResolution);

--- a/src/Amazon.CloudWatch.EMF/Model/MetricsContext.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricsContext.cs
@@ -18,7 +18,7 @@ namespace Amazon.CloudWatch.EMF.Model
         /// <summary>
         /// Holds the metric key and its resolution type for validation checks
         /// </summary>
-        private readonly ConcurrentDictionary<string, StorageResolution> _storageResolutionMetrics = new ConcurrentDictionary<string, StorageResolution>();
+        private readonly ConcurrentDictionary<string, StorageResolution> _metricNameAndResolutionMap = new ConcurrentDictionary<string, StorageResolution>();
 
         public MetricsContext() : this(new RootNode())
         {
@@ -113,10 +113,10 @@ namespace Amazon.CloudWatch.EMF.Model
         /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution</param>
         public void PutMetric(string key, double value, Unit unit, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
-            Validator.ValidateMetric(key, value, storageResolution, _storageResolutionMetrics);
+            Validator.ValidateMetric(key, value, storageResolution, _metricNameAndResolutionMap);
             _metricDirective.PutMetric(key, value, unit, storageResolution);
-            if (!_storageResolutionMetrics.ContainsKey(key))
-                _storageResolutionMetrics.TryAdd(key, storageResolution);
+            if (!_metricNameAndResolutionMap.ContainsKey(key))
+                _metricNameAndResolutionMap.TryAdd(key, storageResolution);
         }
 
         /// <summary>

--- a/src/Amazon.CloudWatch.EMF/Model/MetricsContext.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricsContext.cs
@@ -241,7 +241,7 @@ namespace Amazon.CloudWatch.EMF.Model
         public List<string> Serialize()
         {
             var nodes = new List<RootNode>();
-            if (_rootNode.AWS.MetricDirective.Metrics.Count <= Constants.MAX_METRICS_PER_EVENT)
+            if (_rootNode.AWS.MetricDirective.Metrics.Count <= Constants.MaxMetricsPerEvent)
             {
                 nodes.Add(_rootNode);
             }
@@ -251,10 +251,10 @@ namespace Amazon.CloudWatch.EMF.Model
                 var count = 0;
                 while (count < _rootNode.AWS.MetricDirective.Metrics.Count)
                 {
-                    var metrics = _rootNode.AWS.MetricDirective.Metrics.Skip(count).Take(Constants.MAX_METRICS_PER_EVENT).ToList();
+                    var metrics = _rootNode.AWS.MetricDirective.Metrics.Skip(count).Take(Constants.MaxMetricsPerEvent).ToList();
                     var node = _rootNode.DeepCloneWithNewMetrics(metrics);
                     nodes.Add(node);
-                    count += Constants.MAX_METRICS_PER_EVENT;
+                    count += Constants.MaxMetricsPerEvent;
                 }
             }
 

--- a/src/Amazon.CloudWatch.EMF/Model/MetricsContext.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/MetricsContext.cs
@@ -103,20 +103,19 @@ namespace Amazon.CloudWatch.EMF.Model
         /// Multiple calls using the same key will be stored as an array of scalar values.
         /// </summary>
         /// <example>
-        /// Defaults to StorageResolution : metricContext.PutMetric("Latency", 100)
+        /// Defaults to Standard Resolution : metricContext.PutMetric("Latency", 100)
         /// Standard Resolution metric : metricContext.PutMetric("Latency", 100, Unit.MILLISECONDS)
         /// High Resolution metric : metricContext.PutMetric("Latency", 100, Unit.MILLISECONDS,StorageResolution.HIGH)
         /// </example>
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
         /// <param name="unit">the units of the metric</param>
-        /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Defaults to StandardResolution</param>
         public void PutMetric(string key, double value, Unit unit, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
             Validator.ValidateMetric(key, value, storageResolution, _metricNameAndResolutionMap);
             _metricDirective.PutMetric(key, value, unit, storageResolution);
-            if (!_metricNameAndResolutionMap.ContainsKey(key))
-                _metricNameAndResolutionMap.TryAdd(key, storageResolution);
+            _metricNameAndResolutionMap.TryAdd(key, storageResolution);
         }
 
         /// <summary>
@@ -124,13 +123,13 @@ namespace Amazon.CloudWatch.EMF.Model
         /// Multiple calls using the same key will be stored as an array of scalar values.
         /// </summary>
         /// <example>
-        /// Defaults to StorageResolution : metricContext.PutMetric("Count", 10)
+        /// Defaults to Standard Resolution : metricContext.PutMetric("Count", 10)
         /// StandardResolution metric : metricContext.PutMetric("Count", 10, Unit.MILLISECONDS)
         /// HighResolution metric : metricContext.PutMetric("Count", 100, Unit.MILLISECONDS,StorageResolution.HIGH)
         /// </example>
         /// <param name="key">the name of the metric</param>
         /// <param name="value">the value of the metric</param>
-         /// <param name="storageResolution">the storage resolution of the metric. Default Set to StandardResolution</param>
+        /// <param name="storageResolution">the storage resolution of the metric. Defaults to StandardResolution</param>
         public void PutMetric(string key, double value, StorageResolution storageResolution = StorageResolution.STANDARD)
         {
             PutMetric(key, value, Unit.NONE, storageResolution);

--- a/src/Amazon.CloudWatch.EMF/Model/StorageResolution.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/StorageResolution.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Amazon.CloudWatch.EMF.Model
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum StorageResolution
+    {
+        [EnumMember(Value = "60")]
+        STANDARD,
+
+        [EnumMember(Value = "1")]
+        HIGH,
+
+        [EnumMember(Value = "-1")]
+        UNKNOWN_TO_SDK_VERSION
+    }
+}

--- a/src/Amazon.CloudWatch.EMF/Model/StorageResolution.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/StorageResolution.cs
@@ -11,9 +11,6 @@ namespace Amazon.CloudWatch.EMF.Model
         STANDARD,
 
         [EnumMember(Value = "1")]
-        HIGH,
-
-        [EnumMember(Value = "-1")]
-        UNKNOWN_TO_SDK_VERSION
+        HIGH
     }
 }

--- a/src/Amazon.CloudWatch.EMF/Model/StorageResolution.cs
+++ b/src/Amazon.CloudWatch.EMF/Model/StorageResolution.cs
@@ -1,16 +1,8 @@
-using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-
 namespace Amazon.CloudWatch.EMF.Model
 {
-    [JsonConverter(typeof(StringEnumConverter))]
     public enum StorageResolution
     {
-        [EnumMember(Value = "60")]
-        STANDARD,
-
-        [EnumMember(Value = "1")]
-        HIGH
+        STANDARD = 60,
+        HIGH = 1
     }
 }

--- a/src/Amazon.CloudWatch.EMF/Utils/Validator.cs
+++ b/src/Amazon.CloudWatch.EMF/Utils/Validator.cs
@@ -25,14 +25,14 @@ namespace Amazon.CloudWatch.EMF.Utils
                 throw new InvalidDimensionException("Dimension value must include at least one non-whitespace character");
             }
 
-            if (dimensionName.Length > Constants.MAX_DIMENSION_NAME_LENGTH)
+            if (dimensionName.Length > Constants.MaxDimensionNameLength)
             {
-                throw new InvalidDimensionException($"Dimension name cannot be longer than {Constants.MAX_DIMENSION_NAME_LENGTH} characters: {dimensionName}");
+                throw new InvalidDimensionException($"Dimension name cannot be longer than {Constants.MaxDimensionNameLength} characters: {dimensionName}");
             }
 
-            if (dimensionValue.Length > Constants.MAX_DIMENSION_VALUE_LENGTH)
+            if (dimensionValue.Length > Constants.MaxDimensionValueLength)
             {
-                throw new InvalidDimensionException($"Dimension value cannot be longer than {Constants.MAX_DIMENSION_VALUE_LENGTH} characters: {dimensionValue}");
+                throw new InvalidDimensionException($"Dimension value cannot be longer than {Constants.MaxDimensionValueLength} characters: {dimensionValue}");
             }
 
             if (!IsAscii(dimensionName))
@@ -64,9 +64,9 @@ namespace Amazon.CloudWatch.EMF.Utils
                 throw new InvalidMetricException($"Metric name {name} must include at least one non-whitespace character");
             }
 
-            if (name.Length > Constants.MAX_METRIC_NAME_LENGTH)
+            if (name.Length > Constants.MaxMetricNameLength)
             {
-                throw new InvalidMetricException($"Metric name {name} cannot be longer than {Constants.MAX_METRIC_NAME_LENGTH} characters");
+                throw new InvalidMetricException($"Metric name {name} cannot be longer than {Constants.MaxMetricNameLength} characters");
             }
 
             if (!Double.IsFinite(value))
@@ -92,12 +92,12 @@ namespace Amazon.CloudWatch.EMF.Utils
                 throw new InvalidNamespaceException($"Namespace {@namespace} must include at least one non-whitespace character");
             }
 
-            if (@namespace.Length > Constants.MAX_NAMESPACE_LENGTH)
+            if (@namespace.Length > Constants.MaxNamespaceLength)
             {
-                throw new InvalidNamespaceException($"Namespace {@namespace} cannot be longer than {Constants.MAX_NAMESPACE_LENGTH} characters");
+                throw new InvalidNamespaceException($"Namespace {@namespace} cannot be longer than {Constants.MaxNamespaceLength} characters");
             }
 
-            if (!System.Text.RegularExpressions.Regex.IsMatch(@namespace, Constants.VALID_NAMESPACE_REGEX))
+            if (!System.Text.RegularExpressions.Regex.IsMatch(@namespace, Constants.ValidNamespaceRegex))
             {
                 throw new InvalidNamespaceException($"Namespace {@namespace} contains invalid characters");
             }

--- a/src/Amazon.CloudWatch.EMF/Utils/Validator.cs
+++ b/src/Amazon.CloudWatch.EMF/Utils/Validator.cs
@@ -76,7 +76,7 @@ namespace Amazon.CloudWatch.EMF.Utils
 
             if (storageResolutionMetrics.ContainsKey(name) && storageResolutionMetrics[name] != storageResolution)
             {
-                throw new InvalidMetricException($"Resolution for metrics {name} is already set, A single log event cannot have a metric with two different resolutions");
+                throw new InvalidMetricException($"Resolution for metric {name} is already set, A single log event cannot have a metric with two different resolutions");
             }
         }
 

--- a/src/Amazon.CloudWatch.EMF/Utils/Validator.cs
+++ b/src/Amazon.CloudWatch.EMF/Utils/Validator.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Concurrent;
 using System.Text;
+using Amazon.CloudWatch.EMF.Model;
 
 namespace Amazon.CloudWatch.EMF.Utils
 {
@@ -55,7 +57,7 @@ namespace Amazon.CloudWatch.EMF.Utils
         /// <param name="name">Metric name</param>
         /// <param name="value">Metric value</param>
         /// <exception cref="InvalidMetricException">Thrown when metric name or value is invalid</exception>
-        internal static void ValidateMetric(in string name, in double value)
+        internal static void ValidateMetric(in string name, in double value, in StorageResolution storageResolution, in ConcurrentDictionary<string, StorageResolution> storageResolutionMetrics)
         {
             if (name == null || name.Trim().Length == 0)
             {
@@ -70,6 +72,11 @@ namespace Amazon.CloudWatch.EMF.Utils
             if (!Double.IsFinite(value))
             {
                 throw new InvalidMetricException($"Metric value {value} must be a finite number");
+            }
+
+            if (storageResolutionMetrics.ContainsKey(name) && storageResolutionMetrics[name] != storageResolution)
+            {
+                throw new InvalidMetricException($"Resolution for metrics {name} is already set, A single log event cannot have a metric with two different resolutions");
             }
         }
 

--- a/tests/Amazon.CloudWatch.EMF.Canary/Program.cs
+++ b/tests/Amazon.CloudWatch.EMF.Canary/Program.cs
@@ -52,7 +52,7 @@ namespace Amazon.CloudWatch.EMF.Canary
                     {
                         // https://github.com/dotnet/corefx/blob/3633ea2c6bf9d52029681efeedd84fd7a06eb6ba/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs#L137
                         logger.PutMetric("Memory.RSS", currentProcess.WorkingSet64, Unit.BYTES);
-                        logger.PutMetric("TotalProcessorTime.Minutes", currentProcess.TotalProcessorTime.TotalMinutes, Unit.NONE, StorageResolution.HIGH);
+                        logger.PutMetric("Memory.VirtualMemorySize64", currentProcess.VirtualMemorySize64, Unit.BYTES, StorageResolution.HIGH);
                     }
 
                     logger.PutMetric("Invoke", 1, Unit.NONE);

--- a/tests/Amazon.CloudWatch.EMF.Canary/Program.cs
+++ b/tests/Amazon.CloudWatch.EMF.Canary/Program.cs
@@ -52,6 +52,7 @@ namespace Amazon.CloudWatch.EMF.Canary
                     {
                         // https://github.com/dotnet/corefx/blob/3633ea2c6bf9d52029681efeedd84fd7a06eb6ba/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs#L137
                         logger.PutMetric("Memory.RSS", currentProcess.WorkingSet64, Unit.BYTES);
+                        logger.PutMetric("TotalProcessorTime.Minutes", currentProcess.TotalProcessorTime.TotalMinutes, Unit.NONE, StorageResolution.HIGH);
                     }
 
                     logger.PutMetric("Invoke", 1, Unit.NONE);

--- a/tests/Amazon.CloudWatch.EMF.IntegrationTests/MetricsLoggerIntegrationTest.cs
+++ b/tests/Amazon.CloudWatch.EMF.IntegrationTests/MetricsLoggerIntegrationTest.cs
@@ -115,14 +115,11 @@ namespace Amazon.CloudWatch.EMF.IntegrationTests
             return res;
         }
 
-        private void LogMetric(String metricName, bool isHighResolution = false)
+        private void LogMetric(String metricName)
         {
             MetricsLogger logger = new MetricsLogger(new EnvironmentProvider(EnvironmentConfigurationProvider.Config, new ResourceFetcher()), NullLoggerFactory.Instance);
             logger.PutDimensions(_dimensions);
-            if (isHighResolution)
-                logger.PutMetric(metricName, 100, Unit.MILLISECONDS, StorageResolution.HIGH);
-            else
-                logger.PutMetric(metricName, 100, Unit.MILLISECONDS, StorageResolution.STANDARD);
+            logger.PutMetric(metricName, 100, Unit.MILLISECONDS, StorageResolution.STANDARD);
             logger.Flush();
         }
 

--- a/tests/Amazon.CloudWatch.EMF.IntegrationTests/MetricsLoggerIntegrationTest.cs
+++ b/tests/Amazon.CloudWatch.EMF.IntegrationTests/MetricsLoggerIntegrationTest.cs
@@ -115,11 +115,14 @@ namespace Amazon.CloudWatch.EMF.IntegrationTests
             return res;
         }
 
-        private void LogMetric(String metricName)
+        private void LogMetric(String metricName, bool isHighResolution = false)
         {
             MetricsLogger logger = new MetricsLogger(new EnvironmentProvider(EnvironmentConfigurationProvider.Config, new ResourceFetcher()), NullLoggerFactory.Instance);
             logger.PutDimensions(_dimensions);
-            logger.PutMetric(metricName, 100, Unit.MILLISECONDS);
+            if (isHighResolution)
+                logger.PutMetric(metricName, 100, Unit.MILLISECONDS, StorageResolution.HIGH);
+            else
+                logger.PutMetric(metricName, 100, Unit.MILLISECONDS, StorageResolution.STANDARD);
             logger.Flush();
         }
 

--- a/tests/Amazon.CloudWatch.EMF.Tests/Environment/EC2EnvironmentTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Environment/EC2EnvironmentTests.cs
@@ -198,7 +198,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Environment
             // Act
             var result = environment.Type;
             // Assert
-            Assert.Equal(Constants.UNKNOWN, result);
+            Assert.Equal(Constants.Unknown, result);
         }
 
         [Fact]

--- a/tests/Amazon.CloudWatch.EMF.Tests/Logger/MetricsLoggerTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Logger/MetricsLoggerTests.cs
@@ -404,6 +404,15 @@ namespace Amazon.CloudWatch.EMF.Tests.Logger
 
             _metricsLogger.PutMetric("TestMetric", 1, Unit.COUNT, StorageResolution.HIGH);
             _metricsLogger.Flush();
+
+            var metricDirective = typeof(MetricsContext)
+              .GetField("_metricDirective", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+              .GetValue(_sink.MetricsContext) as MetricDirective;
+
+            Assert.True(metricDirective.Metrics.Count() == 1);
+
+            var metricDefinition = metricDirective.Metrics.FirstOrDefault(m => m.Name == "TestMetric");
+            Assert.Equal(StorageResolution.HIGH, metricDefinition.StorageResolution);
         }
 
 

--- a/tests/Amazon.CloudWatch.EMF.Tests/Logger/MetricsLoggerTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Logger/MetricsLoggerTests.cs
@@ -381,6 +381,13 @@ namespace Amazon.CloudWatch.EMF.Tests.Logger
         // }
 
         [Fact]
+        public void PutMetric_WithSameMetricHavingDifferentResolution_ThrowsInvalidMetricException()
+        {
+              _metricsLogger.PutMetric("TestMetric", 1, Unit.COUNT,StorageResolution.STANDARD);
+              Assert.Throws<InvalidMetricException>(() =>  _metricsLogger.PutMetric("TestMetric", 1, Unit.COUNT,StorageResolution.HIGH));
+        }
+
+        [Fact]
         public void TestPutMetaData()
         {
             string expectedKey = "testKey";

--- a/tests/Amazon.CloudWatch.EMF.Tests/Logger/MetricsLoggerTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Logger/MetricsLoggerTests.cs
@@ -315,6 +315,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Logger
 
             Assert.Equal(expectedValue, metricDefinition.Values[0]);
             Assert.Equal(Unit.NONE, metricDefinition.Unit);
+            Assert.Equal(StorageResolution.STANDARD, metricDefinition.StorageResolution);
         }
 
         [Fact]
@@ -333,6 +334,23 @@ namespace Amazon.CloudWatch.EMF.Tests.Logger
 
             Assert.Equal(expectedValue, metricDefinition.Values[0]);
             Assert.Equal(Unit.MILLISECONDS, metricDefinition.Unit);
+            Assert.Equal(StorageResolution.STANDARD, metricDefinition.StorageResolution);
+        }
+
+        [Fact]
+        public void TestPutMetricWithHighResolutionCheck()
+        {
+            string expectedKey = "test";
+            double expectedValue = 2.0;
+            _metricsLogger.PutMetric(expectedKey, expectedValue, Unit.MILLISECONDS,StorageResolution.HIGH);
+            _metricsLogger.Flush();
+
+            var metricDirective = typeof(MetricsContext)
+              .GetField("_metricDirective", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+              .GetValue(_sink.MetricsContext) as MetricDirective;
+
+            var metricDefinition = metricDirective.Metrics.FirstOrDefault(m => m.Name == expectedKey);
+            Assert.Equal(StorageResolution.HIGH, metricDefinition.StorageResolution);
         }
 
         [Theory]
@@ -353,6 +371,14 @@ namespace Amazon.CloudWatch.EMF.Tests.Logger
             string metricName = new string('a', Constants.MAX_METRIC_NAME_LENGTH + 1);
             Assert.Throws<InvalidMetricException>(() => _metricsLogger.PutMetric(metricName, 1, Unit.NONE));
         }
+
+        // [Fact]
+        // public void PutMetric_WithSameMetricWithDifferentResolution_ThrowsInvalidMetricException()
+        // {
+        //       _metricsLogger.PutMetric("TestMetric", 1, Unit.COUNT,StorageResolution.Strap  );
+        //     _metricsLogger.Flush();
+        //     Assert.Throws<InvalidMetricException>(() => _metricsLogger.PutMetric(metricName, 1, Unit.NONE));
+        // }
 
         [Fact]
         public void TestPutMetaData()

--- a/tests/Amazon.CloudWatch.EMF.Tests/Logger/MetricsLoggerTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Logger/MetricsLoggerTests.cs
@@ -234,7 +234,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Logger
         [Fact]
         public void SetNamespace_WithNameTooLong_ThrowsInvalidNamespaceException()
         {
-            string namespaceValue = new string('a', Constants.MAX_NAMESPACE_LENGTH + 1);
+            string namespaceValue = new string('a', Constants.MaxNamespaceLength + 1);
             Assert.Throws<InvalidNamespaceException>(() => _metricsLogger.SetNamespace(namespaceValue));
         }
 
@@ -384,7 +384,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Logger
         [Fact]
         public void PutMetric_WithNameTooLong_ThrowsInvalidMetricException()
         {
-            string metricName = new string('a', Constants.MAX_METRIC_NAME_LENGTH + 1);
+            string metricName = new string('a', Constants.MaxMetricNameLength + 1);
             Assert.Throws<InvalidMetricException>(() => _metricsLogger.PutMetric(metricName, 1, Unit.NONE));
         }
 

--- a/tests/Amazon.CloudWatch.EMF.Tests/Model/DimensionSetTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Model/DimensionSetTests.cs
@@ -49,7 +49,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Model
             Assert.Throws<InvalidDimensionException>(() =>
             {
                 var dimensionSet = new DimensionSet();
-                string dimensionName = new string('a', Constants.MAX_DIMENSION_NAME_LENGTH + 1);
+                string dimensionName = new string('a', Constants.MaxDimensionNameLength + 1);
                 dimensionSet.AddDimension(dimensionName, "value");
             });
         }
@@ -60,7 +60,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Model
             Assert.Throws<InvalidDimensionException>(() =>
             {
                 var dimensionSet = new DimensionSet();
-                string dimensionValue = new string('a', Constants.MAX_DIMENSION_VALUE_LENGTH + 1);
+                string dimensionValue = new string('a', Constants.MaxDimensionValueLength + 1);
                 dimensionSet.AddDimension("name", dimensionValue);
             });
         }

--- a/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDefinitionTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDefinitionTests.cs
@@ -32,7 +32,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Model
         [Fact]
         public void MetricDefinition_WithUnitAndValue_Returns_ValidJson()
         {
-            MetricDefinition metricDefinition = new MetricDefinition("Time", Unit.MILLISECONDS, 10);
+            MetricDefinition metricDefinition = new MetricDefinition("Time", 10, Unit.MILLISECONDS);
 
             string metricString = JsonConvert.SerializeObject(metricDefinition);
 
@@ -43,13 +43,23 @@ namespace Amazon.CloudWatch.EMF.Tests.Model
         [Fact]
         public void MetricDefinition_AddValue_Returns_ValidValues()
         {
-            MetricDefinition metricDefinition = new MetricDefinition("Time", Unit.MILLISECONDS, 10);
+            MetricDefinition metricDefinition = new MetricDefinition("Time", 10, Unit.MILLISECONDS);
 
             Assert.Equal(new List<double>() { 10 }, metricDefinition.Values);
 
             metricDefinition.AddValue(20);
 
             Assert.Equal(new List<double>() { 10, 20 }, metricDefinition.Values);
+        }
+
+        [Fact]
+        public void MetricDefinition_WithHighResolution_Returns_ValidJson()
+        {
+             MetricDefinition metricDefinition = new MetricDefinition("Time", 10, Unit.MILLISECONDS,StorageResolution.HIGH);
+             
+             string metricString = JsonConvert.SerializeObject(metricDefinition);
+             
+             Assert.Equal("{\"Name\":\"Time\",\"Unit\":\"Milliseconds\",\"StorageResolution\":\"1\"}", metricString);
         }
     }
 }

--- a/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDefinitionTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDefinitionTests.cs
@@ -41,6 +41,49 @@ namespace Amazon.CloudWatch.EMF.Tests.Model
         }
 
         [Fact]
+        public void MetricDefinition_WithHighResolution_Returns_ValidJson()
+        {
+            MetricDefinition metricDefinition = new MetricDefinition("Time", 10, Unit.MILLISECONDS, StorageResolution.HIGH);
+
+            string metricString = JsonConvert.SerializeObject(metricDefinition);
+
+            Assert.Equal("{\"Name\":\"Time\",\"Unit\":\"Milliseconds\",\"StorageResolution\":1}", metricString);
+        }
+
+        [Fact]
+        public void MetricDefinition_WithStandardResolution_Returns_ValidJson()
+        {
+            MetricDefinition metricDefinition = new MetricDefinition("Time", 10, Unit.MILLISECONDS, StorageResolution.STANDARD);
+
+            string metricString = JsonConvert.SerializeObject(metricDefinition);
+
+            Assert.Equal("{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}", metricString);
+        }
+
+        [Fact]
+        public void MetricDefinition_WithStandardResolutionAndWithoutUnit_Returns_ValidJson()
+        {
+            MetricDefinition metricDefinition = new MetricDefinition("Time", StorageResolution.STANDARD);
+
+            string metricString = JsonConvert.SerializeObject(metricDefinition);
+
+            Assert.Equal("{\"Name\":\"Time\",\"Unit\":\"None\"}", metricString);
+            Assert.Empty(metricDefinition.Values);
+        }
+
+        [Fact]
+        public void MetricDefinition_WithHighResolutionAndWithoutUnit_Returns_ValidJson()
+        {
+            MetricDefinition metricDefinition = new MetricDefinition("Time", StorageResolution.HIGH);
+
+            string metricString = JsonConvert.SerializeObject(metricDefinition);
+
+            Assert.Equal("{\"Name\":\"Time\",\"Unit\":\"None\",\"StorageResolution\":1}", metricString);
+            Assert.Empty(metricDefinition.Values);
+        }
+
+
+        [Fact]
         public void MetricDefinition_AddValue_Returns_ValidValues()
         {
             MetricDefinition metricDefinition = new MetricDefinition("Time", 10, Unit.MILLISECONDS);
@@ -50,16 +93,6 @@ namespace Amazon.CloudWatch.EMF.Tests.Model
             metricDefinition.AddValue(20);
 
             Assert.Equal(new List<double>() { 10, 20 }, metricDefinition.Values);
-        }
-
-        [Fact]
-        public void MetricDefinition_WithHighResolution_Returns_ValidJson()
-        {
-             MetricDefinition metricDefinition = new MetricDefinition("Time", 10, Unit.MILLISECONDS,StorageResolution.HIGH);
-             
-             string metricString = JsonConvert.SerializeObject(metricDefinition);
-             
-             Assert.Equal("{\"Name\":\"Time\",\"Unit\":\"Milliseconds\",\"StorageResolution\":\"1\"}", metricString);
         }
     }
 }

--- a/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDirectiveTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDirectiveTests.cs
@@ -100,7 +100,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Model
 
             string jsonString = JsonConvert.SerializeObject(metricDirective);
 
-            Assert.Equal("{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"None\",\"StorageResolution\":\"1\"}],\"Dimensions\":[[]]}", jsonString);
+            Assert.Equal("{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"None\",\"StorageResolution\":1}],\"Dimensions\":[[]]}", jsonString);
 
         }
     }

--- a/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDirectiveTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDirectiveTests.cs
@@ -103,17 +103,5 @@ namespace Amazon.CloudWatch.EMF.Tests.Model
 
             Assert.Equal("{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[],\"Dimensions\":[[\"Region\",\"Instance\"]]}", jsonString);
         }
-
-        [Fact]
-        public void MetricDirective_PutMetricHighResolution_Returns_ValidJson()
-        {
-            MetricDirective metricDirective = new MetricDirective();
-            metricDirective.PutMetric("Time", 10,StorageResolution.HIGH);
-
-            string jsonString = JsonConvert.SerializeObject(metricDirective);
-
-            Assert.Equal("{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"None\",\"StorageResolution\":1}],\"Dimensions\":[[]]}", jsonString);
-
-        }
     }
 }

--- a/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDirectiveTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDirectiveTests.cs
@@ -91,5 +91,17 @@ namespace Amazon.CloudWatch.EMF.Tests.Model
 
             Assert.Equal("{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[],\"Dimensions\":[[\"Region\",\"Instance\"]]}", jsonString);
         }
+
+        [Fact]
+        public void MetricDirective_PutMetricHighResolution_Returns_ValidJson()
+        {
+            MetricDirective metricDirective = new MetricDirective();
+            metricDirective.PutMetric("Time", 10,StorageResolution.HIGH);
+
+            string jsonString = JsonConvert.SerializeObject(metricDirective);
+
+            Assert.Equal("{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"None\",\"StorageResolution\":\"1\"}],\"Dimensions\":[[]]}", jsonString);
+
+        }
     }
 }

--- a/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDirectiveTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Model/MetricDirectiveTests.cs
@@ -44,6 +44,18 @@ namespace Amazon.CloudWatch.EMF.Tests.Model
         }
 
         [Fact]
+        public void MetricDirective_PutMetricHighResolution_Returns_ValidJson()
+        {
+            MetricDirective metricDirective = new MetricDirective();
+            metricDirective.PutMetric("Time", 10, StorageResolution.HIGH);
+
+            string jsonString = JsonConvert.SerializeObject(metricDirective);
+
+            Assert.Equal("{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"None\",\"StorageResolution\":1}],\"Dimensions\":[[]]}", jsonString);
+
+        }
+
+        [Fact]
         public void MetricDirective_PutSameMetricMultipleTimes_Returns_ValidValues()
         {
             MetricDirective metricDirective = new MetricDirective();

--- a/tests/Amazon.CloudWatch.EMF.Tests/Sink/AgentSinkTests.cs
+++ b/tests/Amazon.CloudWatch.EMF.Tests/Sink/AgentSinkTests.cs
@@ -15,7 +15,7 @@ namespace Amazon.CloudWatch.EMF.Tests.Sink
         private string _message;
         public void SendMessage(string message)
         {
-            message = _message;
+            _message = message;
         }
 
         public string GetMessage()


### PR DESCRIPTION
Description of changes:

Added support for High Resolution Metrics. Customers can specify an optional property - storageResolution of the metrics in putMetric() call. If resolution is not specified, metrics will be emitted with standard resolution.

Covered Unit Test methods.

Updated README.md and examples folder.

Updated the canary. See the image below for Memory.VirtualMemorySize64 Memory usage. (Note: We will have to wait until the feature is enabled to get metrics in high resolution for the canary)

<img width="1462" alt="Screen Shot 2023-01-09 at 2 40 45 PM" src="https://user-images.githubusercontent.com/118546401/211422717-73c02aa9-db4a-4b9d-9d0e-00b6f71fe611.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
