### PR TITLE
Update Amazon.CloudWatch.EMF.csproj

### DIFF
--- a/src/Amazon.CloudWatch.EMF/Amazon.CloudWatch.EMF.csproj
+++ b/src/Amazon.CloudWatch.EMF/Amazon.CloudWatch.EMF.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
         <CodeAnalysisRuleSet>Amazon.CloudWatch.EMF.ruleset</CodeAnalysisRuleSet>
     </PropertyGroup>
 


### PR DESCRIPTION
MultiTarget .net standard 2.1 & .net core 3.1.

*Description of changes: Allow .net standard targeting. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
