### PR TITLE
Add awsfirelens log driver to example documentation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ With Docker images, using the `awslogs` log driver will send your container logs
 
 ## ECS and Fargate
 
-With ECS and Fargate, you can use the `awsfirelens` (recommended ) or `awslogs` log driver to have your logs sent to CloudWatch Logs on your behalf. After configuring the options for your preferred log driver, you may write your EMF logs to STDOUT and they will be processed.
+With ECS and Fargate, you can use the `awsfirelens` (recommended) or `awslogs` log driver to have your logs sent to CloudWatch Logs on your behalf. After configuring the options for your preferred log driver, you may write your EMF logs to STDOUT and they will be processed.
 
 [`awsfirelens` documentation](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,9 @@ With Docker images, using the `awslogs` log driver will send your container logs
 
 ## ECS and Fargate
 
-With ECS and Fargate, you can use the `awslogs` log driver to have your logs sent to CloudWatch Logs on your behalf. After configuring your task to use the `awslogs` log driver, you may write your EMF logs to STDOUT and they will be processed.
+With ECS and Fargate, you can use the `awsfirelens` (recommended ) or `awslogs` log driver to have your logs sent to CloudWatch Logs on your behalf. After configuring the options for your preferred log driver, you may write your EMF logs to STDOUT and they will be processed.
+
+[`awsfirelens` documentation](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit)
 
 [ECS documentation on `awslogs` log driver](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add documentation of `awsfirelens` log driver for ECS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
