### PR TITLE
feat: changes emf middleware to avoid allocating a new stopwatch instance per request

### DIFF
--- a/src/Amazon.CloudWatch.EMF.Web/ApplicationBuilderExtensions.cs
+++ b/src/Amazon.CloudWatch.EMF.Web/ApplicationBuilderExtensions.cs
@@ -61,8 +61,8 @@ namespace Amazon.CloudWatch.EMF.Web
         {
             app.Use(async (context, next) =>
             {
-                Stopwatch stopWatch = new Stopwatch();
-                stopWatch.Start();
+                var valueStopwatch = ValueStopwatch.StartNew();
+                
                 await next.Invoke();
                 var config = context.RequestServices.GetRequiredService<EMF.Config.IConfiguration>();
                 var logger = context.RequestServices.GetRequiredService<IMetricsLogger>();
@@ -73,8 +73,9 @@ namespace Amazon.CloudWatch.EMF.Web
                 }
 
                 await action(context, logger);
-                stopWatch.Stop();
-                logger.PutMetric("Time", stopWatch.ElapsedMilliseconds, Model.Unit.MILLISECONDS);
+                
+                var elapsedTime = valueStopwatch.GetElapsedTime();
+                logger.PutMetric("Time", elapsedTime.TotalMilliseconds, Model.Unit.MILLISECONDS);
             });
         }
     }

--- a/src/Amazon.CloudWatch.EMF.Web/ValueStopwatch.cs
+++ b/src/Amazon.CloudWatch.EMF.Web/ValueStopwatch.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Amazon.CloudWatch.EMF.Web
+{
+    internal readonly struct ValueStopwatch
+    {
+        private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+        private readonly long _startTimestamp;
+
+        public bool IsActive => _startTimestamp != 0;
+
+        private ValueStopwatch(long startTimestamp)
+        {
+            _startTimestamp = startTimestamp;
+        }
+
+        public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+
+        public TimeSpan GetElapsedTime()
+        {
+            // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be literally the first thing executed when the machine boots to be 0.
+            // So it being 0 is a clear indication of default(ValueStopwatch)
+            if (!IsActive)
+            {
+                throw new InvalidOperationException(
+                    "An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
+            }
+
+            var end = Stopwatch.GetTimestamp();
+
+            var timestampDelta = end - _startTimestamp;
+            var ticks = (long)(TimestampToTicks * timestampDelta);
+            return new TimeSpan(ticks);
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*

In this pull request I have changed _IApplicationBuilder.UseEmfMiddleware_ middleware to avoid allocating a new instance of the Stopwatch class every request. As the project still uses dotnet core 3.1 I needed to introduce a new struct - from [.net source code](https://source.dot.net/#Microsoft.AspNetCore.Mvc.Core/src/Shared/ValueStopwatch/ValueStopwatch.cs,510774ca21949635,references) - to deal with the logic behind calculating the time difference between start and end of the request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
